### PR TITLE
Add Isaac Lab velocity RL as a second track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - removed the leftover Genesis `evaluation/quant_eval.py` (it pointed at a local `/tmp` pipeline);
 - dropped tracked `controller.log` files (gitignore already excludes `*.log`);
 - experiment READMEs no longer claim those logs are in git;
+- Isaac Lab velocity-curriculum configs live in `rl/isaaclab_custom/` as a second track;
 - seam JSON / AMP evidence stay in `kairoi-k/kine2go-research`.
 
 No controller algorithm is changed by this curation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Unitree Go2 MuJoCo control research
 
-Research fork of [`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco) for **stand → walk → lie** sequencing and a model-based diagonal trot on Unitree Go2. Not a product, not a general control library, and not the Kine2Go imitation work.
+Research fork of [`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco) for **stand → walk → lie** sequencing, a model-based diagonal trot, and an Isaac Lab velocity-RL second track on Unitree Go2. Not a product, not a general control library, and not the Kine2Go imitation work.
 
-> **What this repo actually is.** A 500 Hz LowCmd state machine that interpolates through stand-up, a settle hold, trot, a blend back to stand, then lie-down. Reliable cruise in this stack is about **0.13–0.18 m/s**. Faster running in this project was Isaac Lab velocity RL (omitted here); motion imitation lives in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
+> **What this repo actually is.** Two tracks. The onboarding result is a 500 Hz LowCmd state machine: stand-up, settle, trot, blend back to stand, lie-down. Reliable C++ cruise is about **0.13–0.18 m/s**. The second track is Isaac Lab velocity RL (`rl/`): command curricula up to **±3.5 m/s**, fast but short-stride. Motion imitation lives in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
 
 Development milestone `73ac543` is provenance for the archive. It need not appear in a clean public snapshot. This repository is that snapshot.
 
@@ -33,12 +33,12 @@ cmake --build example/cpp/build -j"$(nproc)"
 
 Stand-walk-lie (after the simulator is up): see [`example/cpp/README.md`](example/cpp/README.md). `go2sim task` is the sequenced entry; `go2sim walk` / `go2sim fast` are trot-only (fast ≈ 0.18 m/s with a looser torque gate).
 
-## Other tracks (not this tree)
+## Tracks
 
 | Track | Where |
 |---|---|
-| Model-based C++ locomotion | this repository |
-| Isaac Lab velocity RL (fast, short-stride) | development archive; `rl/` is a note only |
+| Model-based C++ stand-walk-lie + slow trot | `example/cpp/` (promoted) |
+| Isaac Lab velocity RL (fast, short-stride) | `rl/isaaclab_custom/` (configs; checkpoints not in git) |
 | Kine2Go imitation, AMP, seam JSON | [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research) |
 
 ## Map
@@ -47,7 +47,7 @@ Stand-walk-lie (after the simulator is up): see [`example/cpp/README.md`](exampl
 example/cpp/       controller, tests, runners, retained experiment artifacts
 simulate/          Unitree MuJoCo simulator base
 unitree_robots/    robot models
-rl/                pointer to omitted exploratory RL
+rl/                Isaac Lab velocity-curriculum configs (second track)
 patches/           simulator/runtime patches
 scripts/           environment helpers
 docs/              architecture, reproducibility, research history
@@ -56,6 +56,7 @@ docs/              architecture, reproducibility, research history
 ## Docs
 
 - [`docs/RESEARCH_INDEX.md`](docs/RESEARCH_INDEX.md) — claims vs this tree
+- [`rl/README.md`](rl/README.md) — Isaac Lab velocity RL second track
 - [`docs/RESEARCH_HISTORY.md`](docs/RESEARCH_HISTORY.md) — milestone history
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — runtime/control architecture
 - [`docs/CODE_GUIDE.md`](docs/CODE_GUIDE.md) — source map

--- a/UPSTREAM_AND_CONTRIBUTIONS.md
+++ b/UPSTREAM_AND_CONTRIBUTIONS.md
@@ -11,7 +11,7 @@ This repository combines the Unitree MuJoCo simulator with research-specific C++
 | MuJoCo | DeepMind | physics; 3.3.6 in the research environment |
 | Robot/URDF assets | Unitree and other upstream sources | keep upstream terms |
 
-Isaac Lab / Genesis / Kine2Go are used in companion work, not as implementations in this curated tree.
+Isaac Lab is present here only as recorded velocity-curriculum configs under `rl/`. Genesis / Kine2Go imitation is a companion repository.
 
 Original Unitree READMEs: `docs/upstream/`. The repository root README is the research-project README (avoids case-only collisions with `readme.md`).
 
@@ -22,6 +22,7 @@ Original Unitree READMEs: `docs/upstream/`. The repository root README is the re
 - world/support feedback and simulation instrumentation;
 - constrained contact-force/wrench allocation;
 - incremental dynamics-informed WBC components with guarded fallback;
+- Isaac Lab Go2 velocity-curriculum configs (second track);
 - controlled experiment runners and retained evidence.
 
 Reliable cruise is about 0.15 m/s in this stack. This is not a claim of demo-speed locomotion or a complete full-dynamics WBC.

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -39,6 +39,8 @@ A valid extension should preserve or version:
 
 Do not attach Kine2Go seam or AMP numbers to this repository. Those artifacts are in the companion imitation fork.
 
+Isaac Lab velocity RL uses a separate stack (see `rl/isaaclab_custom/ENV_SNAPSHOT.md`). Configs are in git; the `model_54950` checkpoint is not.
+
 ## Curated-release boundary
 
 The public candidate contains source code and repository-sized evidence needed to understand the promoted result. Disposable run directories, generated build trees, local checkpoints, private workspace notes, and machine-specific caches are intentionally omitted. The development archive remains the place for complete historical archaeology.

--- a/docs/RESEARCH_HISTORY.md
+++ b/docs/RESEARCH_HISTORY.md
@@ -28,9 +28,9 @@ This document summarizes milestone-level research progress. It intentionally exc
 
 **Work.** The repository explored a small MuJoCo PPO implementation and later Isaac Lab / RSL-RL training. The experiments exposed evaluation and training-design pitfalls, including policies that could score well on coarse velocity metrics while producing undesirable or unstable motion.
 
-**Result.** This track remains exploratory. Isaac Lab velocity curricula reached high commanded speeds with a short-stride gait; those policies and videos are not in this curated tree. The work informed later imitation experiments but is not a promoted result here.
+**Result.** Isaac Lab velocity curricula reached commanded speeds up to ±3.5 m/s with a short-stride gait (`model_54950`). That is a useful speed result and not a natural-gait result. Configs are in `rl/isaaclab_custom/`; checkpoints stay in the archive.
 
-**Evidence.** `rl/README.md`. Generated policy checkpoints are omitted.
+**Evidence.** `rl/README.md`, `rl/isaaclab_custom/`.
 
 ## 4. Motion imitation moved to a companion repository
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -1,6 +1,6 @@
 # Research index
 
-This repository records **model-based Go2 control in MuJoCo**: a sequenced stand / walk / lie task and a diagonal-trot stack. It does not own the Kine2Go seam or AMP results.
+This repository records **model-based Go2 control in MuJoCo** as the promoted result, plus an Isaac Lab velocity-RL second track. It does not own the Kine2Go seam or AMP results.
 
 ## Promoted implementation
 
@@ -17,13 +17,26 @@ This repository records **model-based Go2 control in MuJoCo**: a sequenced stand
 
 **Supported claim:** the sequenced task and a slow, measurable trot run in this simulator stack.
 
-**Outside the claim:** demo-speed running, natural animal gait, sim-to-real, or command-conditioned imitation.
+**Outside the C++ claim:** demo-speed running from this controller, natural animal gait, sim-to-real, or command-conditioned imitation.
 
 Entry points: `example/cpp/`, `docs/ARCHITECTURE.md`, `example/cpp/experiments/CATALOG.md`.
 
-## Not in this repository
+## Second track — Isaac Lab velocity RL
 
-Isaac Lab velocity RL (including 3.5 m/s command curricula) and Kine2Go / AMP / seam JSON live elsewhere. `rl/` is a historical note; the implementations and checkpoints are omitted. Imitation evidence is in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
+Isaac Lab / RSL-RL velocity tracking after the C++ speed ceiling. Configs: `rl/isaaclab_custom/`. Snapshot: `rl/isaaclab_custom/ENV_SNAPSHOT.md`.
+
+| Item | Record |
+|---|---|
+| Task | Go2 flat velocity tracking, command curricula ±2.0 → ±3.5 m/s |
+| Recorded policy | `model_54950` (not in git) |
+| Gait | fast, short-stride; official velocity-task reward, no reference motion |
+| Comparison clips | archive `speed_0.5ms` … `speed_3.5ms` |
+
+**Supported claim:** the recorded policy follows high commanded speeds in that Isaac Lab stack.
+
+**Outside the claim:** natural gait, sim-to-real, or that C++ in this repo can reach 3.5 m/s. `error_vel_xy` is tracking error, not body speed.
+
+Kine2Go / AMP / seam JSON remain in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
 
 ## Evidence policy
 

--- a/rl/README.md
+++ b/rl/README.md
@@ -1,7 +1,26 @@
-# Exploratory RL (omitted)
+# Isaac Lab velocity RL (second track)
 
-This directory is a note, not runnable training code.
+This folder is **not** the stand-walk-lie C++ result. After the model-based trot hit a low speed ceiling (~0.15 m/s), Isaac Lab / RSL-RL velocity tracking was trained on Unitree Go2.
 
-After the C++ trot hit a low speed ceiling, Isaac Lab / RSL-RL velocity tracking was tried. Command curricula went up to ±3.5 m/s with a short-stride gait. Those implementations, checkpoints, and videos are in the development archive, not this tree.
+**Supported claim.** Command curricula of `lin_vel_x ∈ ±2.0, ±2.5, ±3.0, ±3.5 m/s` produced a fast policy (`model_54950`) that follows high speed commands in Isaac Lab. Recorded clips are the `speed_0.5ms` … `speed_3.5ms` comparison set.
 
-Kine2Go motion imitation is a separate companion: `kairoi-k/kine2go-research`. Do not read this folder as the source of that result.
+**Outside the claim.** This is short-stride velocity tracking, not a natural animal gait and not sim-to-real. Coarse tracking metrics can look good while the gait stays 碎步. `error_vel_xy` in Isaac Lab logs is tracking error, not body speed.
+
+**Not in git.** Checkpoints (`model_54950.pt`) and videos stay in the development archive. `*.pt` is gitignored.
+
+## What is in tree
+
+Drop-in configs for Isaac Lab’s Go2 velocity task package:
+
+| File | Command range (`lin_vel_x`) |
+|---|---|
+| `isaaclab_custom/flat_fast_env_cfg.py` | ±2.0 m/s |
+| `isaaclab_custom/flat_fast25_env_cfg.py` | ±2.5 m/s |
+| `isaaclab_custom/flat_fast30_env_cfg.py` | ±3.0 m/s |
+| `isaaclab_custom/flat_fast35_env_cfg.py` | ±3.5 m/s |
+
+Recorded training environment: `isaaclab_custom/ENV_SNAPSHOT.md` (Isaac Sim 6.0.1, Isaac Lab v3.0.0-beta2, rsl_rl 5.4.2, Newton / MuJoCo Warp). Local RSL-RL NaN guards (ratio clamp, return guard, loss skip, sample guard) were applied in that environment; they are not vendored here.
+
+To train, copy the four `flat_fast*.py` files into Isaac Lab’s `isaaclab_tasks/.../velocity/config/go2/` next to the official `flat_env_cfg.py`, then launch the `FlatFast35` task with RSL-RL.
+
+Early handwritten MuJoCo PPO in this project is omitted. Imitation / AMP evidence is in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research), not here.

--- a/rl/isaaclab_custom/ENV_SNAPSHOT.md
+++ b/rl/isaaclab_custom/ENV_SNAPSHOT.md
@@ -1,0 +1,12 @@
+# Isaac Lab environment snapshot (2026-08-10)
+
+Recorded stack for the velocity-curriculum runs, including `model_54950`:
+
+- Isaac Sim 6.0.1.0, Isaac Lab v3.0.0-beta2, rsl_rl 5.4.2
+- Newton 1.4.0, MuJoCo 3.11, mujoco_warp 3.11, PyTorch 2.7.1+cu128
+- physics backend: Newton / MuJoCo Warp
+- custom configs: `flat_fast*.py` (command curricula ±2.0 … ±3.5 m/s)
+- local RSL-RL NaN guards: PPO ratio clamp, `compute_returns` guard, loss skip; distribution sample guard
+- evaluated checkpoint identity: `model_54950` (not distributed in git)
+
+This snapshot describes one working environment. It is not a container or lockfile.

--- a/rl/isaaclab_custom/flat_fast25_env_cfg.py
+++ b/rl/isaaclab_custom/flat_fast25_env_cfg.py
@@ -1,0 +1,27 @@
+"""Go2 flat velocity curriculum: lin_vel_x ±2.5 m/s.
+
+Drop-in for Isaac Lab's Go2 velocity task package.
+"""
+from isaaclab.utils.configclass import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.flat_fast_env_cfg import UnitreeGo2FlatFastEnvCfg
+
+
+@configclass
+class UnitreeGo2FlatFast25EnvCfg(UnitreeGo2FlatFastEnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.commands.base_velocity.ranges.lin_vel_x = (-2.5, 2.5)
+        self.commands.base_velocity.ranges.lin_vel_y = (-0.5, 0.5)
+        self.viewer.eye = (2.5, 10.0, 2.0)
+        self.viewer.lookat = (2.5, 0.0, 0.35)
+
+
+@configclass
+class UnitreeGo2FlatFast25EnvCfg_PLAY(UnitreeGo2FlatFast25EnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None

--- a/rl/isaaclab_custom/flat_fast30_env_cfg.py
+++ b/rl/isaaclab_custom/flat_fast30_env_cfg.py
@@ -1,0 +1,24 @@
+"""Go2 flat velocity curriculum: lin_vel_x ±3.0 m/s.
+
+Drop-in for Isaac Lab's Go2 velocity task package.
+"""
+from isaaclab.utils.configclass import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.flat_fast25_env_cfg import UnitreeGo2FlatFast25EnvCfg
+
+
+@configclass
+class UnitreeGo2FlatFast30EnvCfg(UnitreeGo2FlatFast25EnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.commands.base_velocity.ranges.lin_vel_x = (-3.0, 3.0)
+
+
+@configclass
+class UnitreeGo2FlatFast30EnvCfg_PLAY(UnitreeGo2FlatFast30EnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None

--- a/rl/isaaclab_custom/flat_fast35_env_cfg.py
+++ b/rl/isaaclab_custom/flat_fast35_env_cfg.py
@@ -1,0 +1,46 @@
+"""Go2 flat velocity curriculum: lin_vel_x ±3.5 m/s.
+
+Drop-in for Isaac Lab's Go2 velocity task package. Gait terms stay at
+the official velocity-task defaults (no reference-motion imitation).
+"""
+from isaaclab.utils.configclass import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.flat_fast30_env_cfg import UnitreeGo2FlatFast30EnvCfg
+
+
+@configclass
+class UnitreeGo2FlatFast35EnvCfg(UnitreeGo2FlatFast30EnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.commands.base_velocity.ranges.lin_vel_x = (-3.5, 3.5)
+
+
+@configclass
+class UnitreeGo2FlatFast35EnvCfg_PLAY(UnitreeGo2FlatFast35EnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.scene.num_envs = 16
+        import isaaclab.sim as sim_utils
+        from isaaclab.sensors import CameraCfg
+
+        self.scene.tiled_cam = CameraCfg(
+            prim_path="{ENV_REGEX_NS}/Camera",
+            update_period=0.1,
+            height=240,
+            width=320,
+            data_types=["rgb"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0,
+                focus_distance=400.0,
+                horizontal_aperture=20.955,
+                clipping_range=(0.1, 20.0),
+            ),
+            offset=CameraCfg.OffsetCfg(
+                pos=(0.0, -1.5, 0.6),
+                rot=(0.0, 0.0, 0.0, 1.0),
+                convention="world",
+            ),
+        )
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None

--- a/rl/isaaclab_custom/flat_fast_env_cfg.py
+++ b/rl/isaaclab_custom/flat_fast_env_cfg.py
@@ -1,0 +1,30 @@
+"""Go2 flat velocity curriculum: lin_vel_x ±2.0 m/s.
+
+Drop-in next to Isaac Lab's official `flat_env_cfg.py` under
+`isaaclab_tasks/.../velocity/config/go2/`.
+"""
+from isaaclab.utils.configclass import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.flat_env_cfg import UnitreeGo2FlatEnvCfg
+
+
+@configclass
+class UnitreeGo2FlatFastEnvCfg(UnitreeGo2FlatEnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.commands.base_velocity.ranges.lin_vel_x = (-2.0, 2.0)
+        self.commands.base_velocity.ranges.lin_vel_y = (-0.5, 0.5)
+        self.commands.base_velocity.ranges.ang_vel_z = (-1.0, 1.0)
+        self.rewards.track_lin_vel_xy_exp.weight = 1.5
+        self.viewer.eye = (0.8, 6.0, 1.2)
+        self.viewer.lookat = (0.8, 0.0, 0.35)
+
+
+@configclass
+class UnitreeGo2FlatFastEnvCfg_PLAY(UnitreeGo2FlatFastEnvCfg):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None


### PR DESCRIPTION
C++ stand-walk-lie stays the promoted result. Isaac Lab velocity-curriculum configs (±2.0–±3.5 m/s) are now in `rl/isaaclab_custom/`. Checkpoints stay out of git. Claims are separated so the fast RL clips are not read as MuJoCo C++.