### PR TITLE
docs: drop snapshot-meta hedges; make Isaac Lab drop-in explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Call out any change that can alter controller behavior, evaluation semantics, ex
 3. which experiment/config/data/evaluator version supports the result;
 4. whether prior results are superseded, invalidated, or remain comparable.
 
-Do not rewrite a failed experiment out of the record when it matters to the evidence trail. Do not change a frozen protocol or acceptance gate in place after observing results. Claims should remain narrower than the evidence; fixing known implementation defects does not prove that no undiscovered defects exist.
+Do not rewrite a failed experiment out of the record when it matters to the evidence trail. Do not change a frozen protocol or acceptance gate in place after observing results.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Unitree Go2 MuJoCo control research
 
-Research fork of [`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco) for **stand → walk → lie** sequencing, a model-based diagonal trot, and an Isaac Lab velocity-RL second track on Unitree Go2. Not a product, not a general control library, and not the Kine2Go imitation work.
+Research fork of [`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco) for Go2 **stand → walk → lie**, a model-based diagonal trot, and an Isaac Lab velocity-RL second track.
 
-> **What this repo actually is.** Two tracks. The onboarding result is a 500 Hz LowCmd state machine: stand-up, settle, trot, blend back to stand, lie-down. Reliable C++ cruise is about **0.13–0.18 m/s**. The second track is Isaac Lab velocity RL (`rl/`): command curricula up to **±3.5 m/s**, fast but short-stride. Motion imitation lives in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
+Two tracks. The onboarding result is a 500 Hz LowCmd state machine: stand-up, settle, trot, blend back to stand, lie-down. Reliable C++ cruise is about **0.13–0.18 m/s**. Isaac Lab velocity RL (`rl/`) uses command curricula up to **±3.5 m/s**, fast but short-stride. Imitation work is in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
 
-Development milestone `73ac543` is provenance for the archive. It need not appear in a clean public snapshot. This repository is that snapshot.
+Development milestone `73ac543` is provenance for the archive.
 
 ## Contents
 

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -41,14 +41,10 @@ Do not attach Kine2Go seam or AMP numbers to this repository. Those artifacts ar
 
 Isaac Lab velocity RL uses a separate stack (see `rl/isaaclab_custom/ENV_SNAPSHOT.md`). Configs are in git; the `model_54950` checkpoint is not.
 
-## Curated-release boundary
+Bulk logs, build trees, local checkpoints, and machine-specific caches are not in this tree.
 
-The public candidate contains source code and repository-sized evidence needed to understand the promoted result. Disposable run directories, generated build trees, local checkpoints, private workspace notes, and machine-specific caches are intentionally omitted. The development archive remains the place for complete historical archaeology.
-
-This means the curated snapshot is sufficient to inspect the implementation and claim provenance but may not contain every large/private artifact required to reproduce an old development run bit-for-bit. Missing artifacts must be identified explicitly rather than implied to be downloadable.
-
-The companion Kine2Go repository owns a separate motion-imitation evidence chain; artifacts and conclusions should not be substituted between the two projects.
+The companion Kine2Go repository owns the motion-imitation evidence; do not mix numbers across the two projects.
 
 ## Hosted CI
 
-The full simulator/controller build depends on external simulator/runtime packages and is not represented as a generic GitHub-hosted compile gate. Hosted CI checks curated-tree hygiene; the build and kinematics commands above remain the maintained environment-specific smoke path until a portable simulator CI image is validated.
+The full simulator/controller build depends on external simulator/runtime packages and is not a generic GitHub-hosted compile gate. The build and kinematics commands above are the smoke path.

--- a/docs/RESEARCH_HISTORY.md
+++ b/docs/RESEARCH_HISTORY.md
@@ -18,7 +18,7 @@ This document summarizes milestone-level research progress. It intentionally exc
 
 **Work.** The controller was extended with diagonal-trot phase generation, smooth swing trajectories, Raibert landing adjustment, world/support feedback, constrained contact-force allocation, runtime gating, and incremental dynamics-informed feedforward.
 
-**Result.** The stack is a platform for slow, interpretable locomotion experiments. Under the recorded gates, 0.15 m/s is the reliable cruise, 0.18 m/s is marginal, and 0.21 m/s is out of range. Those numbers are configuration-specific, not a theorem about all model-based control.
+**Result.** Under the recorded gates, 0.15 m/s is the reliable cruise, 0.18 m/s is marginal, and 0.21 m/s is out of range.
 
 **Evidence.** `example/cpp/real_trot_go2.cpp`, related controller sources, and the retained experiment artifacts.
 
@@ -34,4 +34,4 @@ This document summarizes milestone-level research progress. It intentionally exc
 
 ## 4. Motion imitation moved to a companion repository
 
-Kine2Go / Genesis imitation, the seam JSON record, and the conditional-AMP negative baseline are in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research). Do not treat this MuJoCo controller repo as the evidence chain for those claims.
+Kine2Go / Genesis imitation, the seam JSON record, and the conditional-AMP negative baseline are in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -52,12 +52,12 @@ The runner uses dedicated DDS domain IDs. Inspect it and `scripts/run_trot.sh` b
 | Retained evidence | `experiments/`, `experiments/CATALOG.md` |
 | Offline analysis | `tools/analysis/` |
 
-The curated release keeps the maintained runners and omits machine-specific historical batch/parameter-sweep launchers. The complete development repository remains the archival record.
+Maintained runners are in `scripts/`. Historical batch/parameter-sweep launchers are not in this tree.
 
 For a higher-level map, see [`../../docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) and [`../../docs/CODE_GUIDE.md`](../../docs/CODE_GUIDE.md).
 
 ## Experiment records
 
-A research-relevant run should identify the code revision, intervention/configuration, seed, input/reference identity, completion status, metric semantics, and evidence path. Disposable outputs belong in ignored local directories; only evidence with durable provenance should be promoted into the curated tree.
+A research-relevant run should identify the code revision, intervention/configuration, seed, input/reference identity, completion status, metric semantics, and evidence path. Disposable outputs belong in ignored local directories.
 
 The current primary claim and its scope are defined in [`../../docs/RESEARCH_INDEX.md`](../../docs/RESEARCH_INDEX.md). Milestone-level context is summarized in [`../../docs/RESEARCH_HISTORY.md`](../../docs/RESEARCH_HISTORY.md).

--- a/example/cpp/experiments/CATALOG.md
+++ b/example/cpp/experiments/CATALOG.md
@@ -14,7 +14,7 @@ Depending on the experiment, a directory may contain configuration snapshots, CS
 - **Supporting evidence:** retained runs that document controller development, repeatability, or failure analysis.
 - **Historical artifacts:** useful for provenance but not current evidence for a promoted claim.
 
-Disposable `_runs/` output is intentionally excluded from the curated release and ignored by Git.
+`_runs/` output is gitignored.
 
 ## Adding a new experiment
 

--- a/rl/README.md
+++ b/rl/README.md
@@ -1,12 +1,12 @@
 # Isaac Lab velocity RL (second track)
 
-This folder is **not** the stand-walk-lie C++ result. After the model-based trot hit a low speed ceiling (~0.15 m/s), Isaac Lab / RSL-RL velocity tracking was trained on Unitree Go2.
+After the model-based trot hit a low speed ceiling (~0.15 m/s), Isaac Lab / RSL-RL velocity tracking was trained on Unitree Go2.
 
 **Supported claim.** Command curricula of `lin_vel_x ∈ ±2.0, ±2.5, ±3.0, ±3.5 m/s` produced a fast policy (`model_54950`) that follows high speed commands in Isaac Lab. Recorded clips are the `speed_0.5ms` … `speed_3.5ms` comparison set.
 
-**Outside the claim.** This is short-stride velocity tracking, not a natural animal gait and not sim-to-real. Coarse tracking metrics can look good while the gait stays 碎步. `error_vel_xy` in Isaac Lab logs is tracking error, not body speed.
+**Outside the claim.** Short-stride velocity tracking, not a natural animal gait and not sim-to-real. Coarse tracking metrics can look good while the gait stays 碎步. `error_vel_xy` in Isaac Lab logs is tracking error, not body speed.
 
-**Not in git.** Checkpoints (`model_54950.pt`) and videos stay in the development archive. `*.pt` is gitignored.
+Checkpoints (`model_54950.pt`) and videos are not in git. `*.pt` is gitignored.
 
 ## What is in tree
 
@@ -21,6 +21,26 @@ Drop-in configs for Isaac Lab’s Go2 velocity task package:
 
 Recorded training environment: `isaaclab_custom/ENV_SNAPSHOT.md` (Isaac Sim 6.0.1, Isaac Lab v3.0.0-beta2, rsl_rl 5.4.2, Newton / MuJoCo Warp). Local RSL-RL NaN guards (ratio clamp, return guard, loss skip, sample guard) were applied in that environment; they are not vendored here.
 
-To train, copy the four `flat_fast*.py` files into Isaac Lab’s `isaaclab_tasks/.../velocity/config/go2/` next to the official `flat_env_cfg.py`, then launch the `FlatFast35` task with RSL-RL.
+Copy the four `flat_fast*.py` files into:
 
-Early handwritten MuJoCo PPO in this project is omitted. Imitation / AMP evidence is in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research), not here.
+```text
+source/isaaclab_tasks/isaaclab_tasks/manager_based/locomotion/velocity/config/go2/
+```
+
+next to official `flat_env_cfg.py`. The configs import each other as `isaaclab_tasks.manager_based.locomotion.velocity.config.go2.flat_fast*_env_cfg`, so they have to live in that package. Then register a gym id in that folder’s `__init__.py`, for example:
+
+```python
+gym.register(
+    id="Isaac-Velocity-Flat-Unitree-Go2-Fast35-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.flat_fast35_env_cfg:UnitreeGo2FlatFast35EnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:UnitreeGo2FlatPPORunnerCfg",
+    },
+)
+```
+
+Train / play with Isaac Lab’s usual RSL-RL entry points against that task id. Local RSL-RL NaN guards used for `model_54950` are not in this tree.
+
+Imitation / AMP evidence is in [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).

--- a/rl/isaaclab_custom/ENV_SNAPSHOT.md
+++ b/rl/isaaclab_custom/ENV_SNAPSHOT.md
@@ -8,5 +8,3 @@ Recorded stack for the velocity-curriculum runs, including `model_54950`:
 - custom configs: `flat_fast*.py` (command curricula ±2.0 … ±3.5 m/s)
 - local RSL-RL NaN guards: PPO ratio clamp, `compute_returns` guard, loss skip; distribution sample guard
 - evaluated checkpoint identity: `model_54950` (not distributed in git)
-
-This snapshot describes one working environment. It is not a container or lockfile.


### PR DESCRIPTION
Drops "not a product / not a library" README framing. Isaac Lab configs now document the exact `isaaclab_tasks` path and a `gym.register` snippet.