### PR TITLE
docs: drop agent-handoff framing

### DIFF
--- a/docs/ARCHIVE_NOTICE.md
+++ b/docs/ARCHIVE_NOTICE.md
@@ -1,5 +1,3 @@
 # Historical records
 
-The detailed experiment ledger under `archive/` predates the public-repository curation pass. It is retained because it records accepted, rejected, superseded, and diagnostic experiments that are useful for provenance.
-
-Historical entries may mention obsolete file names, machine-local paths, or intermediate project organization. Those references describe the development workspace at the time of the experiment; they are not current setup instructions. Use the top-level README and the current documentation index for supported repository navigation.
+The `archive/` ledger records accepted, rejected, superseded, and diagnostic experiments. Old paths in those notes are historical, not current setup instructions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,5 +11,3 @@ Start here when reading the repository as a research artifact or contributing to
 | [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) | environment, build, smoke checks, and evidence-reproduction rules |
 | [`EXPERIMENT_TEMPLATE.md`](EXPERIMENT_TEMPLATE.md) | template for new research records |
 | [`upstream/`](upstream/) | preserved upstream Unitree MuJoCo README files |
-
-The chronological internal experiment diary is intentionally excluded from the curated public tree. Milestone-level context and promoted evidence are maintained in `RESEARCH_HISTORY.md` and `RESEARCH_INDEX.md`; the complete development repository remains the archival record.

--- a/docs/RESEARCH_HISTORY.md
+++ b/docs/RESEARCH_HISTORY.md
@@ -1,6 +1,6 @@
 # Research history
 
-This document summarizes milestone-level research progress. It intentionally excludes chat transcripts, agent handoffs, private planning notes, and chronological workspace diaries.
+Milestone-level research progress.
 
 ## 1. Low-level control and instrumentation
 


### PR DESCRIPTION
Remove curation-process narration from research notes.