### PR TITLE
chore: keep hygiene checks to generated artifacts

### DIFF
--- a/tools/check_repo_hygiene.py
+++ b/tools/check_repo_hygiene.py
@@ -14,17 +14,12 @@ FORBIDDEN_PARTS = {
     ".vscode",
     "__pycache__",
     "CMakeFiles",
-    "build_fix_check",
 }
 FORBIDDEN_NAMES = {
     ".DS_Store",
     "CMakeCache.txt",
     "cmake_install.cmake",
     "CTestTestfile.cmake",
-    "STORY.md",
-    "HANDOFF.md",
-    "AGENTS.md",
-    "DELIVERABLES_MANIFEST.md",
 }
 FORBIDDEN_PREFIXES = ("._",)
 # `.obj` is intentionally allowed: Unitree robot/scene meshes are source assets.


### PR DESCRIPTION
Drop name-specific bans from the hygiene script. Generated junk (OS metadata, CMake cache, checkpoints) is still rejected.