### PR TITLE
Feed preview terminal velocity into centroidal a_x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `ctest` registers the CPU unit tests (FK still needs the local MuJoCo library).
 - `example/cpp/MODULES.md` points at `docs/CODE_GUIDE.md`.
 - `--wbc-full` centroidal wrench (`W = M a + h`); N-step foothold preview now selects the next Raibert touchdown; stance PD is lowered on that path.
+- Preview terminal velocity error feeds the centroidal `a_x` task on `--wbc-full`.
 
 ## 2026-08-14
 

--- a/docs/WBC_MPC.md
+++ b/docs/WBC_MPC.md
@@ -14,6 +14,7 @@ Stance legs get an extra `M a` torque; gravity/bias `h` is left to the position 
 - stance PD drops to `kWbcFullStanceKp/Kd` (25 / 2.0) so gravity is not double-counted by the position servo;
 - swing legs remain IK + position control;
 - the Raibert kernel takes the first foothold from an N-step preview (`--preview-horizon`, default 4). Remaining steps stay greedy Raibert. Velocity is propagated with a first-order capture model (rearward placement raises forward speed). This is not a receding-horizon QP.
+- remaining terminal velocity error over that horizon sets the centroidal `a_x` task, so the wrench looks ahead instead of only reacting to the current speed error.
 
 ## How to run
 

--- a/example/cpp/locomotion_kernel.h
+++ b/example/cpp/locomotion_kernel.h
@@ -45,6 +45,7 @@ struct GaitKernelResult
     bool footstep_plan_valid = false;
     int preview_n_steps = 0;
     double preview_touchdown_x_m = 0.0;
+    double preview_terminal_velocity_x_mps = 0.0;
 };
 
 class LocomotionKernel

--- a/example/cpp/preview_footstep_horizon.h
+++ b/example/cpp/preview_footstep_horizon.h
@@ -174,4 +174,24 @@ inline bool PlanPreviewFootstepHorizon(
     return true;
 }
 
+inline bool PreviewTerminalAcceleration(
+    double nominal_velocity_x_mps,
+    double terminal_velocity_x_mps,
+    int n_steps,
+    double period_s,
+    double &acc_x_mps2)
+{
+    acc_x_mps2 = 0.0;
+    if (n_steps <= 0 ||
+        !(period_s > 0.0) ||
+        !std::isfinite(nominal_velocity_x_mps) ||
+        !std::isfinite(terminal_velocity_x_mps))
+        return false;
+    const double horizon_s =
+        0.5 * period_s * static_cast<double>(n_steps);
+    acc_x_mps2 =
+        (nominal_velocity_x_mps - terminal_velocity_x_mps) / horizon_s;
+    return std::isfinite(acc_x_mps2);
+}
+
 }  // namespace go2_control

--- a/example/cpp/raibert_trot_kernel.h
+++ b/example/cpp/raibert_trot_kernel.h
@@ -40,6 +40,9 @@ public:
         have_last_gait_time_ = false;
         last_gait_time_s_ = 0.0;
         phase_acc_ = 0.0;  // [Fix 2026-08-13] 连续相位累积
+        last_preview_n_steps_ = 0;
+        last_preview_touchdown_x_m_ = 0.0;
+        last_preview_terminal_velocity_x_mps_ = 0.0;
     }
 
     // [Phase3] 在线步长/周期变更(cycle 边界调用,渐变趋近防冲击)
@@ -138,8 +141,10 @@ public:
         result.velocity_error_x_mps = velocity_error;
         result.nominal_velocity_x_mps = nominal_velocity;  // [Fix 2026-08-13]
         result.footstep_plan_valid = true;
-        result.preview_n_steps = 0;
-        result.preview_touchdown_x_m = 0.0;
+        result.preview_n_steps = last_preview_n_steps_;
+        result.preview_touchdown_x_m = last_preview_touchdown_x_m_;
+        result.preview_terminal_velocity_x_mps =
+            last_preview_terminal_velocity_x_mps_;
 
         const RaibertFootstepPlannerParams planner_params{
             params_.gait.period_s,
@@ -183,8 +188,14 @@ public:
                         return false;
                     }
                     next_touchdown_x_m = preview_output.touchdown_x_m[0];
-                    result.preview_n_steps = preview_output.n_steps;
-                    result.preview_touchdown_x_m = next_touchdown_x_m;
+                    last_preview_n_steps_ = preview_output.n_steps;
+                    last_preview_touchdown_x_m_ = next_touchdown_x_m;
+                    last_preview_terminal_velocity_x_mps_ =
+                        preview_output.terminal_velocity_x_mps;
+                    result.preview_n_steps = last_preview_n_steps_;
+                    result.preview_touchdown_x_m = last_preview_touchdown_x_m_;
+                    result.preview_terminal_velocity_x_mps =
+                        last_preview_terminal_velocity_x_mps_;
                 }
                 else
                 {
@@ -331,6 +342,9 @@ private:
     std::array<LegState, go2::kLegCount> leg_states_{};
     bool have_last_gait_time_ = false;
     double last_gait_time_s_ = 0.0;
+    int last_preview_n_steps_ = 0;
+    double last_preview_touchdown_x_m_ = 0.0;
+    double last_preview_terminal_velocity_x_mps_ = 0.0;
 };
 
 } // namespace go2_control

--- a/example/cpp/test_preview_footstep_horizon.cpp
+++ b/example/cpp/test_preview_footstep_horizon.cpp
@@ -70,6 +70,18 @@ bool CheckInvalidHorizonRejected()
     return !go2_control::PlanPreviewFootstepHorizon(params, {}, output);
 }
 
+bool CheckTerminalAcceleration()
+{
+    double acc = 1.0;
+    if (!go2_control::PreviewTerminalAcceleration(0.105, 0.105, 4, 0.8, acc) ||
+        !Near(acc, 0.0))
+        return false;
+    if (!go2_control::PreviewTerminalAcceleration(0.105, 0.045, 4, 0.8, acc))
+        return false;
+    // horizon = 0.5 * 0.8 * 4 = 1.6 s
+    return Near(acc, (0.105 - 0.045) / 1.6);
+}
+
 }  // namespace
 
 int main()
@@ -77,7 +89,8 @@ int main()
     if (!CheckSingleStepMatchesRaibert() ||
         !CheckNominalHorizonKeepsRaibertFoothold() ||
         !CheckSlowFirstStepIsRearward() ||
-        !CheckInvalidHorizonRejected())
+        !CheckInvalidHorizonRejected() ||
+        !CheckTerminalAcceleration())
     {
         std::cerr << "preview footstep horizon checks failed\n";
         return 1;

--- a/example/cpp/test_raibert_trot_kernel.cpp
+++ b/example/cpp/test_raibert_trot_kernel.cpp
@@ -166,6 +166,21 @@ bool CheckPreviewHorizonClosesLoop()
            Near(slow.touchdown_target_x_m[fr], slow.preview_touchdown_x_m);
 }
 
+bool CheckPreviewPersistsWithinCycle()
+{
+    auto kernel = MakePreviewKernel();
+    go2_control::GaitKernelResult first{};
+    go2_control::GaitKernelResult later{};
+    if (!kernel.Compute(Request(0.0, 0.05), first) ||
+        !kernel.Compute(Request(0.10, 0.05), later))
+        return false;
+    return first.preview_n_steps == 4 &&
+           later.preview_n_steps == 4 &&
+           Near(later.preview_touchdown_x_m, first.preview_touchdown_x_m) &&
+           Near(later.preview_terminal_velocity_x_mps,
+                first.preview_terminal_velocity_x_mps);
+}
+
 } // namespace
 
 int main()
@@ -174,7 +189,8 @@ int main()
         !CheckCycleBoundaryIsContinuous() ||
         !CheckGearShiftPhaseContinuity() ||
         !CheckResetAndInvalidInput() ||
-        !CheckPreviewHorizonClosesLoop())
+        !CheckPreviewHorizonClosesLoop() ||
+        !CheckPreviewPersistsWithinCycle())
     {
         std::cerr << "Raibert trot kernel checks failed\n";
         return 1;

--- a/example/cpp/trot_experiment.h
+++ b/example/cpp/trot_experiment.h
@@ -233,6 +233,10 @@ private:
     bool kernel_footstep_plan_valid_ = false;
     double kernel_velocity_error_x_mps_ = 0.0;
     std::array<double, go2::kLegCount> kernel_touchdown_target_x_m_{};
+    int preview_n_steps_ = 0;
+    double preview_touchdown_x_m_ = 0.0;
+    double preview_terminal_velocity_x_mps_ = 0.0;
+    bool have_preview_terminal_velocity_ = false;
 
     double world_reference_x_m_ = 0.0;
     double world_reference_y_m_ = 0.0;

--- a/example/cpp/trot_experiment_gait.cpp
+++ b/example/cpp/trot_experiment_gait.cpp
@@ -140,6 +140,11 @@ bool TrotExperiment::BuildGaitTargets(
     kernel_footstep_plan_valid_ = gait_result.footstep_plan_valid;
     kernel_velocity_error_x_mps_ = gait_result.velocity_error_x_mps;
     kernel_touchdown_target_x_m_ = gait_result.touchdown_target_x_m;
+    preview_n_steps_ = gait_result.preview_n_steps;
+    preview_touchdown_x_m_ = gait_result.preview_touchdown_x_m;
+    preview_terminal_velocity_x_mps_ =
+        gait_result.preview_terminal_velocity_x_mps;
+    have_preview_terminal_velocity_ = preview_n_steps_ > 0;
     const double phase = gait_result.phase;
     current_phase_ = phase;
     const int cycle_index = gait_result.cycle_index;

--- a/example/cpp/trot_experiment_wbc.cpp
+++ b/example/cpp/trot_experiment_wbc.cpp
@@ -17,6 +17,7 @@
 #include "go2_contact_torque_mapping.h"
 #include "go2_inverse_kinematics.h"
 #include "motion_frame_utils.h"
+#include "preview_footstep_horizon.h"
 
 using namespace unitree::common;
 using namespace unitree::robot;
@@ -243,6 +244,20 @@ void TrotExperiment::UpdateWbcShadow(
                         kShadowWbcMassKg,
                     -3.0, 3.0);
                 a_desired[1] = 0.0;
+                if (params_.wbc_full && have_preview_terminal_velocity_)
+                {
+                    double preview_acc_x = 0.0;
+                    if (go2_control::PreviewTerminalAcceleration(
+                            params_.direction_sign * params_.step_length_m /
+                                params_.period_s,
+                            preview_terminal_velocity_x_mps_,
+                            preview_n_steps_,
+                            params_.period_s,
+                            preview_acc_x))
+                    {
+                        a_desired[0] = Clamp(preview_acc_x, -3.0, 3.0);
+                    }
+                }
             }
             const double bounce_phase =
                 2.0 * kPi * 2.0 / params_.period_s *


### PR DESCRIPTION
## Summary
- N-step preview now keeps its terminal velocity on the gait kernel across ticks.
- `--wbc-full` uses that remaining horizon error for the centroidal `a_x` task (`W = M a + h`).
- Foothold selection is unchanged from PR #7.

Still not a receding-horizon QP. Speed vs the 0.15 m/s baseline is not claimed.

## Test plan
- `python3 tools/check_repo_hygiene.py`
- `ctest --test-dir example/cpp/build --output-on-failure` (16/16)