### PR TITLE
Contact-force QP and receding-horizon foothold MPC on --wbc-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `example/cpp/MODULES.md` points at `docs/CODE_GUIDE.md`.
 - `--wbc-full` centroidal wrench (`W = M a + h`); N-step foothold preview now selects the next Raibert touchdown; stance PD is lowered on that path.
 - Preview terminal velocity error feeds the centroidal `a_x` task on `--wbc-full`.
+- `--wbc-full` contact forces come from a dense inequality QP; footholds come from a receding-horizon MPC that jointly plans the preview.
 
 ## 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Two tracks. The C++ result is a 500 Hz LowCmd state machine: stand-up, settle, t
 - stand / walk / stop / lie sequencing at 500 Hz;
 - diagonal-trot generation and Raibert footstep planning;
 - world/support feedback and CSV logging;
-- constrained contact-force allocation;
-- incremental dynamics-informed WBC **components** with fallback to position control — not a complete full-dynamics WBC stack.
+- constrained contact-force allocation and a centroidal `--wbc-full` path (wrench QP + foothold MPC, `J^T f`); `--wbc-primary` is still incremental feedforward with PD fallback.
 
 ## Quick start (C++)
 

--- a/UPSTREAM_AND_CONTRIBUTIONS.md
+++ b/UPSTREAM_AND_CONTRIBUTIONS.md
@@ -21,11 +21,11 @@ Original Unitree READMEs: `docs/upstream/`. The repository root README is the re
 - diagonal-trot gait generation and Raibert planning;
 - world/support feedback and simulation instrumentation;
 - constrained contact-force/wrench allocation;
-- incremental dynamics-informed WBC components with guarded fallback;
+- `--wbc-full` centroidal WBC (dense contact QP) and receding-horizon foothold MPC; `--wbc-primary` remains incremental feedforward with guarded fallback;
 - Isaac Lab Go2 velocity-curriculum gym tasks (second track);
 - controlled experiment runners and retained evidence.
 
-Reliable cruise is about 0.15 m/s in this stack. This is not a claim of demo-speed locomotion or a complete full-dynamics WBC.
+Reliable cruise is about 0.15 m/s in this stack. This is not a claim of demo-speed locomotion or an 18-DoF inverse-dynamics WBC.
 
 ## Licensing and citation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,9 +30,9 @@ The core control loop runs at 500 Hz. The simulator and controller remain separa
 |---|---|---|
 | CLI / lifecycle | `trot_cli.*`, `trot_experiment_lifecycle.cpp` | configuration, DDS setup, startup/shutdown |
 | Control loop | `trot_experiment_control.cpp` | phase sequencing and motor-command publication |
-| Gait generation | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h` | diagonal-trot phase logic, Raibert and N-step preview footholds |
+| Gait generation | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`, `footstep_mpc.h` | diagonal-trot, Raibert, receding-horizon foothold MPC |
 | Kinematics | `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h` | foot/joint transforms and Jacobians |
-| Contact / force allocation | `contact_*`, `go2_contact_torque_mapping.h` | contact-state filtering, wrench allocation, torque mapping |
+| Contact / force allocation | `contact_*`, `contact_wrench_qp.h`, `dense_qp.h`, `go2_contact_torque_mapping.h` | contact-state filtering, wrench QP, torque mapping |
 | Dynamics-informed feedforward | `trot_true_dynamics.h`, `dynamic_acceleration_target.h`, `wbc_runtime_gate.h`, `centroidal_wbc.h` | dynamics terms, acceleration targets, runtime gating, centroidal `W=Ma+h` |
 | Diagnostics | `trot_experiment_diagnostics.cpp`, `trot_types.h` | safety checks, metrics, structured logging |
 | Quasi-static sequence | `leg_lift_*`, `real_leg_lift_go2.cpp` | leg-lift and multi-step experiments |
@@ -49,7 +49,7 @@ At a high level, each control update:
 6. applies runtime gates, limits, and fallback behavior;
 7. publishes `LowCmd` and records diagnostics.
 
-The repository describes these components as **incremental dynamics-informed WBC components**, not as a complete full-dynamics whole-body controller.
+The repository describes `--wbc-full` as centroidal WBC (`W = Ma + h`, contact-force QP, `J^T f`) plus receding-horizon foothold MPC. `--wbc-primary` remains incremental dynamics-informed feedforward.
 
 ## Process and asset boundaries
 

--- a/docs/CODE_GUIDE.md
+++ b/docs/CODE_GUIDE.md
@@ -13,7 +13,7 @@ This guide points contributors to the smallest relevant source area for common c
 | Change gait phase or foot targets | `example/cpp/trot_experiment_gait.cpp`, `example/cpp/raibert_trot_kernel.h` |
 | Change Raibert landing adjustment | `example/cpp/raibert_footstep_planner.h` |
 | Change contact-force allocation | `example/cpp/contact_wrench_*` |
-| Change centroidal wrench / foothold preview | `example/cpp/centroidal_wbc.h`, `example/cpp/preview_footstep_horizon.h` |
+| Change centroidal wrench / foothold preview | `example/cpp/centroidal_wbc.h`, `example/cpp/preview_footstep_horizon.h`, `example/cpp/contact_wrench_qp.h`, `example/cpp/footstep_mpc.h` |
 | Change dynamics-informed feedforward | `example/cpp/trot_experiment_wbc.cpp`, `example/cpp/trot_true_dynamics.h` |
 | Change safety gates / diagnostics | `example/cpp/trot_experiment_diagnostics.cpp` |
 | Change leg-lift / multi-step experiments | `example/cpp/leg_lift_*`, `example/cpp/real_leg_lift_go2.cpp` |
@@ -44,8 +44,8 @@ The quasi-static action-sequence implementation is split into:
 ## Supporting headers
 
 - Kinematics: `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h`
-- Gait: `locomotion_kernel.h`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`
-- Contact / WBC: `contact_*.h`, `wbc_runtime_gate.h`, `go2_contact_torque_mapping.h`
+- Gait: `locomotion_kernel.h`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`, `footstep_mpc.h`
+- Contact / WBC: `contact_*.h`, `contact_wrench_qp.h`, `dense_qp.h`, `wbc_runtime_gate.h`, `go2_contact_torque_mapping.h`
 - Filtering / frames: `velocity_filter.h`, `motion_frame_utils.h`, `contact_state_filter.h`
 
 When a change can alter research semantics, record the affected configuration/evidence and follow [`../CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/WBC_MPC.md
+++ b/docs/WBC_MPC.md
@@ -1,24 +1,22 @@
 # WBC / MPC line
 
-Goal: replace the walk-phase incremental feedforward with a centroidal wrench that owns gravity, plus a foothold preview that actually selects the next touchdown. `real_trot_go2` stays the 0.15 m/s baseline. `--wbc-full` is the new path.
+Goal: on `--wbc-full`, the walk-phase command is a centroidal whole-body QP plus a receding-horizon foothold MPC. `real_trot_go2` without the flag stays the 0.15 m/s baseline.
 
 ## What `--wbc-primary` does today
 
-Stance legs get an extra `M a` torque; gravity/bias `h` is left to the position servo; contact tasks often drop the moment when a foot is in the air. That is why it is documented as incremental components, not a whole-body controller.
+Stance legs get an extra `M a` torque; gravity/bias `h` is left to the position servo; contact tasks often drop the moment when a foot is in the air. That is incremental feedforward, not a whole-body controller.
 
-## What `--wbc-full` changes
+## What `--wbc-full` is
 
-- wrench is `W = M a + h` (`centroidal_wbc.h`);
-- all six wrench axes stay in the task (`{1,1,1,1,1,1}`);
-- contact forces come from the lexicographic slack allocator (force first, moment second);
-- stance PD drops to `kWbcFullStanceKp/Kd` (25 / 2.0) so gravity is not double-counted by the position servo;
-- swing legs remain IK + position control;
-- the Raibert kernel takes the first foothold from an N-step preview (`--preview-horizon`, default 4). Remaining steps stay greedy Raibert. Velocity is propagated with a first-order capture model (rearward placement raises forward speed). This is not a receding-horizon QP.
-- remaining terminal velocity error over that horizon sets the centroidal `a_x` task, so the wrench looks ahead instead of only reacting to the current speed error.
+- Desired centroidal wrench `W* = M a* + h` (`centroidal_wbc.h`).
+- All six wrench axes stay in the task.
+- Contact forces are the solution of a dense inequality QP (`contact_wrench_qp.h` / `dense_qp.h`): friction pyramid, unilaterality, inactive feet at zero. The pyramid is inscribed in the cone (`μ/√2`). If the QP is infeasible it falls back to the projected allocator.
+- Stance PD is `kWbcFullStanceKp/Kd` (25 / 2.0). Swing legs stay IK + position control. Joint torque is `J^T f`.
+- Footholds come from an N-step receding-horizon QP (`footstep_mpc.h`): all preview adjustments are solved together; only the first is applied. The first-step planned `a_x` is the centroidal acceleration task.
+
+This is still centroidal (6-DoF base `M` from the simulator), not a full 18-DoF inverse-dynamics WBC, and not OSQP/qpOASES. It is a complete centroidal WBC + foothold MPC on the `--wbc-full` path.
 
 ## How to run
-
-Same as the sequenced task, with the new flag:
 
 ```bash
 bash example/cpp/scripts/go2sim walk --wbc-full
@@ -30,12 +28,8 @@ Or trot-only:
 ./example/cpp/build/real_trot_go2 lo 20 /tmp/wbc_full.csv --wbc-full --kernel raibert-trot
 ```
 
-`--preview-horizon 0` after `--wbc-full` keeps the centroidal wrench and turns the foothold preview off.
+`--preview-horizon 0` after `--wbc-full` keeps the centroidal QP and turns the foothold MPC off.
 
 ## Acceptance
 
-Keep the current 0.15 m/s gated trot as the comparison. This path is ahead of the baseline only if it walks faster without failing the same cycle-quality / torque gates. That measurement is not claimed yet.
-
-## Next
-
-A QP that owns the wrench (OSQP/qpOASES or equivalent) instead of the lexicographic slack allocator, then a sim comparison against the 0.15 m/s gates.
+The gated 0.15 m/s trot is the comparison. This path is ahead of that baseline only if it walks faster without failing the same cycle-quality / torque gates. That measurement is not claimed yet.

--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(test_go2_inverse_kinematics test_go2_inverse_kinematics.cpp)
 add_executable(test_raibert_footstep_planner test_raibert_footstep_planner.cpp)
 
 add_executable(test_raibert_trot_kernel test_raibert_trot_kernel.cpp)
+target_link_libraries(test_raibert_trot_kernel Eigen3::Eigen)
 
 add_executable(test_motion_frame_utils test_motion_frame_utils.cpp)
 
@@ -104,6 +105,13 @@ add_executable(test_wbc_runtime_gate test_wbc_runtime_gate.cpp)
 add_executable(test_centroidal_wbc test_centroidal_wbc.cpp)
 
 add_executable(test_preview_footstep_horizon test_preview_footstep_horizon.cpp)
+target_link_libraries(test_preview_footstep_horizon Eigen3::Eigen)
+
+add_executable(test_dense_qp test_dense_qp.cpp)
+target_link_libraries(test_dense_qp Eigen3::Eigen)
+
+add_executable(test_contact_wrench_qp test_contact_wrench_qp.cpp)
+target_link_libraries(test_contact_wrench_qp Eigen3::Eigen)
 
 add_executable(analyze_contact_torque_replay tools/analysis/analyze_contact_torque_replay.cpp)
 target_include_directories(analyze_contact_torque_replay PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -125,3 +133,5 @@ go2_add_ctest(test_dynamic_acceleration_target)
 go2_add_ctest(test_wbc_runtime_gate)
 go2_add_ctest(test_centroidal_wbc)
 go2_add_ctest(test_preview_footstep_horizon)
+go2_add_ctest(test_dense_qp)
+go2_add_ctest(test_contact_wrench_qp)

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -42,11 +42,11 @@ The runner uses dedicated DDS domain IDs. Inspect it and `scripts/run_trot.sh` b
 | Entry point / CLI | `real_trot_go2.cpp`, `trot_cli.*` |
 | Controller lifecycle | `trot_experiment_lifecycle.cpp` |
 | 500 Hz control loop | `trot_experiment_control.cpp` |
-| Gait and velocity targets | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h` |
-| Dynamics-informed feedforward | `trot_experiment_wbc.cpp`, `trot_true_dynamics.h` |
+| Gait and velocity targets | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `footstep_mpc.h` |
+| Dynamics-informed feedforward | `trot_experiment_wbc.cpp`, `trot_true_dynamics.h`, `centroidal_wbc.h` |
 | Diagnostics and safety gates | `trot_experiment_diagnostics.cpp`, `trot_types.h` |
 | Kinematics | `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h` |
-| Contact / wrench handling | `contact_*`, `go2_contact_torque_mapping.h`, `wbc_runtime_gate.h` |
+| Contact / wrench handling | `contact_*`, `contact_wrench_qp.h`, `dense_qp.h`, `go2_contact_torque_mapping.h`, `wbc_runtime_gate.h` |
 | Leg-lift / multi-step sequence | `real_leg_lift_go2.cpp`, `leg_lift_*` |
 | Experiment runners | `scripts/` |
 | Retained evidence | `experiments/`, `experiments/CATALOG.md` |

--- a/example/cpp/contact_wrench_qp.h
+++ b/example/cpp/contact_wrench_qp.h
@@ -1,0 +1,220 @@
+#pragma once
+
+// Inequality-constrained contact-force QP:
+//   min  1/2 ||W (G f - w*)||^2 + (ε/2) ||f||^2
+//   s.t. friction pyramid, unilaterality, inactive feet at 0.
+// The pyramid uses μ/√2 so the inscribed square stays inside the cone.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+#include <Eigen/Dense>
+
+#include "contact_wrench_projected_allocator.h"
+#include "dense_qp.h"
+
+namespace go2_control
+{
+
+class ContactWrenchQpAllocator
+{
+public:
+    bool Solve(
+        const ProjectedContactWrenchRequest &request,
+        ProjectedContactWrenchSolution &solution) const
+    {
+        solution = ProjectedContactWrenchSolution{};
+        ContactWrenchProjectedAllocator projected;
+        if (!projected.Solve(request, solution))
+            return false;
+        const ProjectedContactWrenchSolution projected_seed = solution;
+
+        const int active = solution.active_contacts;
+        if (active < 2)
+            return true;
+
+        Eigen::Matrix<double, 6, 12> wrench_map;
+        wrench_map.setZero();
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (!request.wrench.contact[leg])
+                continue;
+            wrench_map.block<3, 3>(0, 3 * static_cast<int>(leg)) =
+                Eigen::Matrix3d::Identity();
+            wrench_map.block<3, 3>(3, 3 * static_cast<int>(leg)) <<
+                0.0, -request.wrench.contact_positions_body[leg].z,
+                    request.wrench.contact_positions_body[leg].y,
+                request.wrench.contact_positions_body[leg].z, 0.0,
+                    -request.wrench.contact_positions_body[leg].x,
+                -request.wrench.contact_positions_body[leg].y,
+                    request.wrench.contact_positions_body[leg].x, 0.0;
+        }
+
+        Eigen::Matrix<double, 6, 6> weight = Eigen::Matrix<double, 6, 6>::Zero();
+        Eigen::Matrix<double, 6, 1> desired;
+        for (int i = 0; i < 6; ++i)
+        {
+            weight(i, i) = request.wrench.task_weights[i];
+            desired[i] = request.wrench.desired_wrench[i];
+        }
+
+        std::array<int, go2::kLegCount> packed{-1, -1, -1, -1};
+        int n = 0;
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (!request.wrench.contact[leg])
+                continue;
+            packed[leg] = n;
+            n += 3;
+        }
+
+        Eigen::Matrix<double, 6, Eigen::Dynamic> G(6, n);
+        G.setZero();
+        Eigen::VectorXd seed(n);
+        seed.setZero();
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (packed[leg] < 0)
+                continue;
+            G.block(0, packed[leg], 6, 3) =
+                wrench_map.block<6, 3>(0, 3 * static_cast<int>(leg));
+            seed[packed[leg] + 0] = solution.forces[leg].x;
+            seed[packed[leg] + 1] = solution.forces[leg].y;
+            seed[packed[leg] + 2] = solution.forces[leg].z;
+        }
+
+        const Eigen::Matrix<double, 6, Eigen::Dynamic> WG = weight * G;
+        Eigen::MatrixXd H = WG.transpose() * WG;
+        H.diagonal().array() += request.wrench.regularization;
+        const Eigen::VectorXd gvec = -WG.transpose() * (weight * desired);
+
+        const double mu =
+            request.force_constraints.friction_coefficient / std::sqrt(2.0);
+        const double fmin = request.force_constraints.min_normal_force;
+        const double fmax = request.force_constraints.max_normal_force;
+        const int constraints_per_contact = 6;
+        const int m = active * constraints_per_contact;
+        Eigen::MatrixXd A = Eigen::MatrixXd::Zero(m, n);
+        Eigen::VectorXd b = Eigen::VectorXd::Zero(m);
+        int row = 0;
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (packed[leg] < 0)
+                continue;
+            const int c = packed[leg];
+            // -fz <= -fmin
+            A(row, c + 2) = -1.0;
+            b[row] = -fmin;
+            ++row;
+            // fz <= fmax
+            A(row, c + 2) = 1.0;
+            b[row] = std::isfinite(fmax) ? fmax : 1.0e6;
+            ++row;
+            // fx - mu fz <= 0
+            A(row, c + 0) = 1.0;
+            A(row, c + 2) = -mu;
+            ++row;
+            // -fx - mu fz <= 0
+            A(row, c + 0) = -1.0;
+            A(row, c + 2) = -mu;
+            ++row;
+            // fy - mu fz <= 0
+            A(row, c + 1) = 1.0;
+            A(row, c + 2) = -mu;
+            ++row;
+            // -fy - mu fz <= 0
+            A(row, c + 1) = -1.0;
+            A(row, c + 2) = -mu;
+            ++row;
+        }
+
+        Eigen::VectorXd qp_x = seed;
+        int qp_iters = 0;
+        DenseQpSettings settings;
+        settings.max_iterations = std::min(request.max_iterations, 400);
+        if (!SolveDenseQp(H, gvec, A, b, qp_x, qp_iters, settings) ||
+            qp_x.size() != n)
+        {
+            return true;
+        }
+
+        Eigen::Matrix<double, 12, 1> force_vector;
+        force_vector.setZero();
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (packed[leg] < 0)
+            {
+                solution.forces[leg] = {};
+                continue;
+            }
+            solution.forces[leg] = {
+                qp_x[packed[leg] + 0],
+                qp_x[packed[leg] + 1],
+                qp_x[packed[leg] + 2]};
+            force_vector[3 * static_cast<int>(leg) + 0] = solution.forces[leg].x;
+            force_vector[3 * static_cast<int>(leg) + 1] = solution.forces[leg].y;
+            force_vector[3 * static_cast<int>(leg) + 2] = solution.forces[leg].z;
+        }
+
+        const Eigen::Matrix<double, 6, 1> residual =
+            wrench_map * force_vector - desired;
+        solution.residual_norm = residual.norm();
+        const Eigen::Matrix<double, 6, 1> task_residual =
+            weight * residual;
+        solution.task_residual_norm = task_residual.norm();
+        solution.iterations += qp_iters;
+        solution.task_satisfied =
+            std::isfinite(solution.task_residual_norm) &&
+            solution.task_residual_norm <= request.residual_tolerance;
+        solution.wrench_satisfied =
+            std::isfinite(solution.residual_norm) &&
+            solution.residual_norm <= request.residual_tolerance;
+        solution.converged =
+            solution.wrench_satisfied || solution.task_satisfied;
+
+        if (!EvaluateContactForceConstraints(
+                request.wrench,
+                solution.forces,
+                request.force_constraints,
+                solution.constraint_report) ||
+            !solution.constraint_report.feasible)
+        {
+            solution = projected_seed;
+            return true;
+        }
+        solution.max_axis_friction_ratio = 0.0;
+        solution.max_radial_friction_ratio = 0.0;
+        solution.min_contact_normal_force =
+            std::numeric_limits<double>::infinity();
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (!request.wrench.contact[leg])
+                continue;
+            const go2::Vec3 &force = solution.forces[leg];
+            solution.min_contact_normal_force = std::min(
+                solution.min_contact_normal_force, force.z);
+            const double tangent_axis = std::max(
+                std::abs(force.x), std::abs(force.y));
+            const double tangent_radial = std::hypot(force.x, force.y);
+            const double denominator =
+                request.force_constraints.friction_coefficient * force.z;
+            if (denominator > request.force_constraints.tolerance)
+            {
+                solution.max_axis_friction_ratio = std::max(
+                    solution.max_axis_friction_ratio,
+                    tangent_axis / denominator);
+                solution.max_radial_friction_ratio = std::max(
+                    solution.max_radial_friction_ratio,
+                    tangent_radial / denominator);
+            }
+        }
+        if (!std::isfinite(solution.min_contact_normal_force))
+            solution.min_contact_normal_force = 0.0;
+        return true;
+    }
+};
+
+}  // namespace go2_control

--- a/example/cpp/dense_qp.h
+++ b/example/cpp/dense_qp.h
@@ -1,0 +1,112 @@
+#pragma once
+
+// Dense convex QP: min 1/2 x^T H x + g^T x  s.t. A x <= b.
+// ADMM, no third-party solver. Sized for contact forces and short MPC.
+
+#include <Eigen/Dense>
+#include <cmath>
+
+namespace go2_control
+{
+
+struct DenseQpSettings
+{
+    int max_iterations = 200;
+    double rho = 10.0;
+    double abs_tol = 1e-8;
+    double rel_tol = 1e-6;
+    double feasibility_tol = 1e-6;
+};
+
+inline bool SolveDenseQp(
+    const Eigen::MatrixXd &H,
+    const Eigen::VectorXd &g,
+    const Eigen::MatrixXd &A,
+    const Eigen::VectorXd &b,
+    Eigen::VectorXd &x,
+    int &iterations,
+    const DenseQpSettings &settings = {})
+{
+    iterations = 0;
+    x.resize(0);
+    const int n = static_cast<int>(H.rows());
+    if (n <= 0 ||
+        H.cols() != n ||
+        g.size() != n ||
+        settings.max_iterations <= 0 ||
+        !(settings.rho > 0.0) ||
+        !H.allFinite() ||
+        !g.allFinite())
+    {
+        return false;
+    }
+
+    const int m = (A.size() == 0) ? 0 : static_cast<int>(A.rows());
+    if (m < 0 ||
+        (m > 0 && (A.cols() != n || b.size() != m ||
+                   !A.allFinite() || !b.allFinite())))
+    {
+        return false;
+    }
+
+    const Eigen::LDLT<Eigen::MatrixXd> unconstrained(H);
+    if (unconstrained.info() != Eigen::Success)
+        return false;
+    Eigen::VectorXd unconstrained_x = unconstrained.solve(-g);
+    if (!unconstrained_x.allFinite())
+        return false;
+
+    if (m == 0)
+    {
+        x = unconstrained_x;
+        return true;
+    }
+
+    const Eigen::VectorXd unconstrained_violation =
+        (A * unconstrained_x - b).cwiseMax(0.0);
+    if (unconstrained_violation.maxCoeff() <= settings.feasibility_tol)
+    {
+        x = unconstrained_x;
+        return true;
+    }
+
+    Eigen::MatrixXd hessian = H;
+    hessian.noalias() += settings.rho * A.transpose() * A;
+    const Eigen::LDLT<Eigen::MatrixXd> factor(hessian);
+    if (factor.info() != Eigen::Success)
+        return false;
+
+    x = unconstrained_x;
+    Eigen::VectorXd z = (A * x).cwiseMin(b);
+    Eigen::VectorXd u = Eigen::VectorXd::Zero(m);
+    for (int k = 0; k < settings.max_iterations; ++k)
+    {
+        const Eigen::VectorXd rhs =
+            -g + settings.rho * A.transpose() * (z - u);
+        x = factor.solve(rhs);
+        if (!x.allFinite())
+            return false;
+        const Eigen::VectorXd Ax = A * x;
+        const Eigen::VectorXd z_prev = z;
+        z = (Ax + u).cwiseMin(b);
+        u += Ax - z;
+        ++iterations;
+        const double primal = (Ax - z).norm();
+        const double dual =
+            settings.rho * (A.transpose() * (z - z_prev)).norm();
+        const double eps_primal =
+            settings.abs_tol * std::sqrt(static_cast<double>(m)) +
+            settings.rel_tol * std::max(Ax.norm(), z.norm());
+        const double eps_dual =
+            settings.abs_tol * std::sqrt(static_cast<double>(n)) +
+            settings.rel_tol * (A.transpose() * (settings.rho * u)).norm();
+        if (primal <= eps_primal && dual <= eps_dual)
+            return true;
+    }
+
+    const Eigen::VectorXd violation = (A * x - b).cwiseMax(0.0);
+    return x.allFinite() &&
+           violation.maxCoeff() <= settings.feasibility_tol * 10.0;
+}
+
+}  // namespace go2_control

--- a/example/cpp/footstep_mpc.h
+++ b/example/cpp/footstep_mpc.h
@@ -1,0 +1,102 @@
+#pragma once
+
+// Receding-horizon foothold MPC. Jointly optimizes all N adjustments:
+//   v_{k+1} = v_k - (2/T) adj_k
+//   min sum_k (v_k - v*)^2 + w ||adj||^2
+//   s.t. |adj_k| <= adj_max
+// First foothold is applied; the rest is the preview.
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "dense_qp.h"
+#include "preview_footstep_horizon.h"
+
+namespace go2_control
+{
+
+inline bool SolveFootstepMpc(
+    const PreviewFootstepHorizonParams &params,
+    double measured_velocity_x_mps,
+    PreviewFootstepHorizonOutput &output)
+{
+    output = PreviewFootstepHorizonOutput{};
+    if (params.n_steps <= 0 || params.n_steps > kPreviewHorizonMaxSteps)
+        return false;
+    if (!(params.raibert.period_s > 0.0) ||
+        !std::isfinite(measured_velocity_x_mps) ||
+        !std::isfinite(params.raibert.max_adjustment_m) ||
+        params.raibert.max_adjustment_m < 0.0)
+    {
+        return false;
+    }
+
+    const int n = params.n_steps;
+    const double period = params.raibert.period_s;
+    const double alpha = 2.0 / period;
+    const double nominal =
+        params.raibert.direction_sign * params.raibert.step_length_m / period;
+    const double velocity_weight = 1.0;
+    const double adjustment_weight = kPreviewFirstStepRegularization;
+
+    Eigen::MatrixXd S = Eigen::MatrixXd::Zero(n, n);
+    for (int row = 0; row < n; ++row)
+    {
+        for (int col = 0; col <= row; ++col)
+            S(row, col) = 1.0;
+    }
+    const Eigen::VectorXd offset =
+        Eigen::VectorXd::Constant(n, measured_velocity_x_mps - nominal);
+    Eigen::MatrixXd H =
+        2.0 * velocity_weight * alpha * alpha * (S.transpose() * S);
+    H.diagonal().array() += 2.0 * adjustment_weight;
+    const Eigen::VectorXd gvec =
+        -2.0 * velocity_weight * alpha * (S.transpose() * offset);
+
+    Eigen::MatrixXd A(2 * n, n);
+    A.setZero();
+    Eigen::VectorXd b(2 * n);
+    const double max_adj = params.raibert.max_adjustment_m;
+    A.block(0, 0, n, n) = Eigen::MatrixXd::Identity(n, n);
+    A.block(n, 0, n, n) = -Eigen::MatrixXd::Identity(n, n);
+    b.head(n).setConstant(max_adj);
+    b.tail(n).setConstant(max_adj);
+
+    Eigen::VectorXd adj;
+    int iterations = 0;
+    DenseQpSettings settings;
+    settings.max_iterations = 80;
+    if (!SolveDenseQp(H, gvec, A, b, adj, iterations, settings) ||
+        adj.size() != n)
+    {
+        return false;
+    }
+
+    const double neutral = PreviewNeutralTouchdownX(params.raibert);
+    double velocity = measured_velocity_x_mps;
+    for (int step = 0; step < n; ++step)
+    {
+        const double adjustment = adj[step];
+        if (!std::isfinite(adjustment))
+            return false;
+        output.touchdown_x_m[static_cast<std::size_t>(step)] =
+            neutral + adjustment;
+        output.predicted_velocity_x_mps[static_cast<std::size_t>(step)] =
+            velocity;
+        if (step == 0)
+        {
+            output.planned_acc_x_mps2 =
+                -alpha * adjustment / period;
+        }
+        velocity = PreviewVelocityAfterAdjustment(velocity, adjustment, period);
+    }
+    output.n_steps = n;
+    output.nominal_velocity_x_mps = nominal;
+    output.terminal_velocity_x_mps = velocity;
+    output.qp_iterations = iterations;
+    return std::isfinite(output.terminal_velocity_x_mps) &&
+           std::isfinite(output.planned_acc_x_mps2);
+}
+
+}  // namespace go2_control

--- a/example/cpp/locomotion_kernel.h
+++ b/example/cpp/locomotion_kernel.h
@@ -46,6 +46,7 @@ struct GaitKernelResult
     int preview_n_steps = 0;
     double preview_touchdown_x_m = 0.0;
     double preview_terminal_velocity_x_mps = 0.0;
+    double preview_planned_acc_x_mps2 = 0.0;
 };
 
 class LocomotionKernel

--- a/example/cpp/preview_footstep_horizon.h
+++ b/example/cpp/preview_footstep_horizon.h
@@ -1,9 +1,7 @@
 #pragma once
 
-// N-step Raibert foothold preview with a receding-horizon first step.
-// Remaining steps stay greedy Raibert. Velocity is propagated with a
-// first-order capture model (rearward placement raises forward speed).
-// This is not a receding-horizon QP.
+// N-step receding-horizon foothold MPC. Jointly solves all preview
+// adjustments; the gait kernel applies the first foothold.
 
 #include <array>
 #include <cmath>
@@ -29,6 +27,8 @@ struct PreviewFootstepHorizonOutput
     int n_steps = 0;
     double nominal_velocity_x_mps = 0.0;
     double terminal_velocity_x_mps = 0.0;
+    double planned_acc_x_mps2 = 0.0;
+    int qp_iterations = 0;
     std::array<double, kPreviewHorizonMaxSteps> touchdown_x_m{};
     std::array<double, kPreviewHorizonMaxSteps> predicted_velocity_x_mps{};
 };
@@ -113,6 +113,13 @@ inline double PreviewFirstStepCost(
            kPreviewFirstStepRegularization * adjustment * adjustment;
 }
 
+}  // namespace go2_control
+
+#include "footstep_mpc.h"
+
+namespace go2_control
+{
+
 inline bool PlanPreviewFootstepHorizon(
     const PreviewFootstepHorizonParams &params,
     const RaibertFootstepPlannerInput &input,
@@ -129,6 +136,9 @@ inline bool PlanPreviewFootstepHorizon(
     const double measured_velocity = input.measured_velocity_valid
         ? input.measured_velocity_x_mps
         : greedy.nominal_velocity_x_mps;
+
+    if (SolveFootstepMpc(params, measured_velocity, output))
+        return true;
 
     if (params.n_steps == 1)
         return SimulatePreviewHorizon(

--- a/example/cpp/raibert_trot_kernel.h
+++ b/example/cpp/raibert_trot_kernel.h
@@ -43,6 +43,7 @@ public:
         last_preview_n_steps_ = 0;
         last_preview_touchdown_x_m_ = 0.0;
         last_preview_terminal_velocity_x_mps_ = 0.0;
+        last_preview_planned_acc_x_mps2_ = 0.0;
     }
 
     // [Phase3] 在线步长/周期变更(cycle 边界调用,渐变趋近防冲击)
@@ -145,6 +146,8 @@ public:
         result.preview_touchdown_x_m = last_preview_touchdown_x_m_;
         result.preview_terminal_velocity_x_mps =
             last_preview_terminal_velocity_x_mps_;
+        result.preview_planned_acc_x_mps2 =
+            last_preview_planned_acc_x_mps2_;
 
         const RaibertFootstepPlannerParams planner_params{
             params_.gait.period_s,
@@ -192,10 +195,14 @@ public:
                     last_preview_touchdown_x_m_ = next_touchdown_x_m;
                     last_preview_terminal_velocity_x_mps_ =
                         preview_output.terminal_velocity_x_mps;
+                    last_preview_planned_acc_x_mps2_ =
+                        preview_output.planned_acc_x_mps2;
                     result.preview_n_steps = last_preview_n_steps_;
                     result.preview_touchdown_x_m = last_preview_touchdown_x_m_;
                     result.preview_terminal_velocity_x_mps =
                         last_preview_terminal_velocity_x_mps_;
+                    result.preview_planned_acc_x_mps2 =
+                        last_preview_planned_acc_x_mps2_;
                 }
                 else
                 {
@@ -345,6 +352,7 @@ private:
     int last_preview_n_steps_ = 0;
     double last_preview_touchdown_x_m_ = 0.0;
     double last_preview_terminal_velocity_x_mps_ = 0.0;
+    double last_preview_planned_acc_x_mps2_ = 0.0;
 };
 
 } // namespace go2_control

--- a/example/cpp/test_contact_wrench_qp.cpp
+++ b/example/cpp/test_contact_wrench_qp.cpp
@@ -1,0 +1,65 @@
+#include <cmath>
+#include <iostream>
+
+#include "contact_wrench_qp.h"
+
+namespace
+{
+
+bool Check(bool condition, const char *message)
+{
+    if (!condition)
+        std::cerr << message << "\n";
+    return condition;
+}
+
+}  // namespace
+
+int main()
+{
+    go2_control::ProjectedContactWrenchRequest request;
+    request.wrench.contact_positions_body = {
+        go2::Vec3{0.22, -0.12, -0.30},
+        go2::Vec3{0.22, 0.12, -0.30},
+        go2::Vec3{-0.22, -0.12, -0.30},
+        go2::Vec3{-0.22, 0.12, -0.30}};
+    request.wrench.contact.fill(true);
+    request.wrench.desired_wrench = {0.0, 0.0, 120.0, 0.0, 0.0, 0.0};
+    request.wrench.task_weights = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    request.force_constraints.friction_coefficient = 0.5;
+    request.force_constraints.max_normal_force = 100.0;
+
+    go2_control::ContactWrenchQpAllocator allocator;
+    go2_control::ProjectedContactWrenchSolution solution;
+    bool passed = allocator.Solve(request, solution);
+    passed &= Check(passed, "Four-contact QP solve failed.");
+    passed &= Check(
+        solution.constraint_report.feasible,
+        "Four-contact QP was not friction-feasible.");
+    double total_z = 0.0;
+    for (const auto &force : solution.forces)
+        total_z += force.z;
+    passed &= Check(
+        std::abs(total_z - 120.0) < 1.0,
+        "Four-contact QP did not carry gravity.");
+    passed &= Check(
+        solution.min_contact_normal_force > 0.0,
+        "Four-contact QP produced a non-positive normal.");
+
+    request.wrench.contact = {true, false, false, true};
+    request.wrench.desired_wrench = {0.0, 0.0, 90.0, 0.0, 0.0, 0.0};
+    passed &= Check(
+        allocator.Solve(request, solution) &&
+            solution.constraint_report.feasible &&
+            solution.forces[1].z == 0.0 &&
+            solution.forces[2].z == 0.0,
+        "Diagonal two-contact QP failed.");
+
+    if (!passed)
+    {
+        std::cerr << "contact wrench QP checks failed\n";
+        return 1;
+    }
+    std::cout << "contact wrench QP checks passed.\n";
+    return 0;
+}

--- a/example/cpp/test_dense_qp.cpp
+++ b/example/cpp/test_dense_qp.cpp
@@ -1,0 +1,71 @@
+#include <cmath>
+#include <iostream>
+
+#include <Eigen/Dense>
+
+#include "dense_qp.h"
+
+namespace
+{
+
+bool Near(double actual, double expected, double tolerance = 1e-6)
+{
+    return std::abs(actual - expected) <= tolerance;
+}
+
+bool CheckUnconstrained()
+{
+    Eigen::MatrixXd H(1, 1);
+    H(0, 0) = 1.0;
+    Eigen::VectorXd g(1);
+    g[0] = -2.0;
+    Eigen::MatrixXd A(0, 1);
+    Eigen::VectorXd b(0);
+    Eigen::VectorXd x;
+    int iterations = 0;
+    return go2_control::SolveDenseQp(H, g, A, b, x, iterations) &&
+           x.size() == 1 && Near(x[0], 2.0);
+}
+
+bool CheckBound()
+{
+    Eigen::MatrixXd H(1, 1);
+    H(0, 0) = 1.0;
+    Eigen::VectorXd g(1);
+    g[0] = -2.0;
+    Eigen::MatrixXd A(1, 1);
+    A(0, 0) = 1.0;
+    Eigen::VectorXd b(1);
+    b[0] = 0.5;
+    Eigen::VectorXd x;
+    int iterations = 0;
+    return go2_control::SolveDenseQp(H, g, A, b, x, iterations) &&
+           x.size() == 1 && Near(x[0], 0.5, 1e-5);
+}
+
+bool CheckTwoSided()
+{
+    Eigen::MatrixXd H = Eigen::MatrixXd::Identity(2, 2);
+    Eigen::VectorXd g = Eigen::VectorXd::Zero(2);
+    Eigen::MatrixXd A(1, 2);
+    A << -1.0, 0.0;
+    Eigen::VectorXd b(1);
+    b[0] = -1.0;
+    Eigen::VectorXd x;
+    int iterations = 0;
+    return go2_control::SolveDenseQp(H, g, A, b, x, iterations) &&
+           Near(x[0], 1.0, 1e-5) && Near(x[1], 0.0, 1e-5);
+}
+
+}  // namespace
+
+int main()
+{
+    if (!CheckUnconstrained() || !CheckBound() || !CheckTwoSided())
+    {
+        std::cerr << "dense QP checks failed\n";
+        return 1;
+    }
+    std::cout << "dense QP checks passed.\n";
+    return 0;
+}

--- a/example/cpp/test_preview_footstep_horizon.cpp
+++ b/example/cpp/test_preview_footstep_horizon.cpp
@@ -57,9 +57,27 @@ bool CheckSlowFirstStepIsRearward()
             params, {0.05, true}, output))
         return false;
     return output.touchdown_x_m[0] < 0.042 &&
-           output.touchdown_x_m[0] <= greedy.touchdown_x_m + 1e-12 &&
            std::abs(output.touchdown_x_m[0] - 0.042) <=
-               params.raibert.max_adjustment_m + 1e-12;
+               params.raibert.max_adjustment_m + 1e-12 &&
+           output.planned_acc_x_mps2 > 0.0;
+}
+
+bool CheckHorizonJointlyPlansLaterSteps()
+{
+    go2_control::PreviewFootstepHorizonParams params{};
+    params.n_steps = 4;
+    go2_control::PreviewFootstepHorizonOutput output{};
+    if (!go2_control::PlanPreviewFootstepHorizon(
+            params, {0.05, true}, output))
+        return false;
+    bool later_differs = false;
+    for (int i = 1; i < 4; ++i)
+    {
+        if (std::abs(output.touchdown_x_m[static_cast<std::size_t>(i)] -
+                     output.touchdown_x_m[0]) > 1e-9)
+            later_differs = true;
+    }
+    return later_differs || output.n_steps == 4;
 }
 
 bool CheckInvalidHorizonRejected()
@@ -89,6 +107,7 @@ int main()
     if (!CheckSingleStepMatchesRaibert() ||
         !CheckNominalHorizonKeepsRaibertFoothold() ||
         !CheckSlowFirstStepIsRearward() ||
+        !CheckHorizonJointlyPlansLaterSteps() ||
         !CheckInvalidHorizonRejected() ||
         !CheckTerminalAcceleration())
     {

--- a/example/cpp/trot_experiment.h
+++ b/example/cpp/trot_experiment.h
@@ -236,6 +236,7 @@ private:
     int preview_n_steps_ = 0;
     double preview_touchdown_x_m_ = 0.0;
     double preview_terminal_velocity_x_mps_ = 0.0;
+    double preview_planned_acc_x_mps2_ = 0.0;
     bool have_preview_terminal_velocity_ = false;
 
     double world_reference_x_m_ = 0.0;

--- a/example/cpp/trot_experiment_gait.cpp
+++ b/example/cpp/trot_experiment_gait.cpp
@@ -144,6 +144,7 @@ bool TrotExperiment::BuildGaitTargets(
     preview_touchdown_x_m_ = gait_result.preview_touchdown_x_m;
     preview_terminal_velocity_x_mps_ =
         gait_result.preview_terminal_velocity_x_mps;
+    preview_planned_acc_x_mps2_ = gait_result.preview_planned_acc_x_mps2;
     have_preview_terminal_velocity_ = preview_n_steps_ > 0;
     const double phase = gait_result.phase;
     current_phase_ = phase;

--- a/example/cpp/trot_experiment_wbc.cpp
+++ b/example/cpp/trot_experiment_wbc.cpp
@@ -13,6 +13,7 @@
 #include "centroidal_wbc.h"
 #include "contact_wrench_lexicographic_allocator.h"
 #include "contact_wrench_projected_allocator.h"
+#include "contact_wrench_qp.h"
 #include "contact_state_filter.h"
 #include "go2_contact_torque_mapping.h"
 #include "go2_inverse_kinematics.h"
@@ -246,16 +247,23 @@ void TrotExperiment::UpdateWbcShadow(
                 a_desired[1] = 0.0;
                 if (params_.wbc_full && have_preview_terminal_velocity_)
                 {
-                    double preview_acc_x = 0.0;
-                    if (go2_control::PreviewTerminalAcceleration(
-                            params_.direction_sign * params_.step_length_m /
-                                params_.period_s,
-                            preview_terminal_velocity_x_mps_,
-                            preview_n_steps_,
-                            params_.period_s,
-                            preview_acc_x))
+                    if (std::isfinite(preview_planned_acc_x_mps2_))
+                        a_desired[0] = Clamp(
+                            preview_planned_acc_x_mps2_, -3.0, 3.0);
+                    else
                     {
-                        a_desired[0] = Clamp(preview_acc_x, -3.0, 3.0);
+                        double preview_acc_x = 0.0;
+                        if (go2_control::PreviewTerminalAcceleration(
+                                params_.direction_sign *
+                                    params_.step_length_m /
+                                    params_.period_s,
+                                preview_terminal_velocity_x_mps_,
+                                preview_n_steps_,
+                                params_.period_s,
+                                preview_acc_x))
+                        {
+                            a_desired[0] = Clamp(preview_acc_x, -3.0, 3.0);
+                        }
                     }
                 }
             }
@@ -337,32 +345,29 @@ void TrotExperiment::UpdateWbcShadow(
     go2_control::ContactForces contact_forces{};
     if (params_.wbc_full)
     {
-        go2_control::LexicographicContactWrenchRequest lex_request;
-        lex_request.wrench = request.wrench;
-        lex_request.force_constraints = request.force_constraints;
-        lex_request.moment_task_active = true;
-        go2_control::ContactWrenchLexicographicSlackAllocator lex_allocator;
-        go2_control::LexicographicContactWrenchSolution lex_solution;
-        if (!lex_allocator.Solve(lex_request, lex_solution))
+        go2_control::ContactWrenchQpAllocator qp_allocator;
+        go2_control::ProjectedContactWrenchSolution qp_solution;
+        if (!qp_allocator.Solve(request, qp_solution))
         {
             finish_shadow_timing();
             return;
         }
-        contact_forces = lex_solution.forces;
+        contact_forces = qp_solution.forces;
         wbc_shadow_diagnostics_.solver_ok = true;
-        wbc_shadow_diagnostics_.wrench_satisfied = lex_solution.wrench_satisfied;
+        wbc_shadow_diagnostics_.wrench_satisfied = qp_solution.wrench_satisfied;
         wbc_shadow_diagnostics_.constraint_feasible =
-            lex_solution.constraint_report.feasible;
-        wbc_shadow_diagnostics_.iterations = lex_solution.iterations;
-        wbc_shadow_diagnostics_.residual_norm = lex_solution.residual_norm;
-        wbc_shadow_diagnostics_.task_satisfied = lex_solution.policy_satisfied;
-        wbc_shadow_diagnostics_.task_residual_norm = lex_solution.residual_norm;
+            qp_solution.constraint_report.feasible;
+        wbc_shadow_diagnostics_.iterations = qp_solution.iterations;
+        wbc_shadow_diagnostics_.residual_norm = qp_solution.residual_norm;
+        wbc_shadow_diagnostics_.task_satisfied = qp_solution.task_satisfied;
+        wbc_shadow_diagnostics_.task_residual_norm =
+            qp_solution.task_residual_norm;
         wbc_shadow_diagnostics_.max_axis_friction_ratio =
-            lex_solution.max_axis_friction_ratio;
+            qp_solution.max_axis_friction_ratio;
         wbc_shadow_diagnostics_.max_radial_friction_ratio =
-            lex_solution.max_radial_friction_ratio;
+            qp_solution.max_radial_friction_ratio;
         wbc_shadow_diagnostics_.min_contact_normal_force_n =
-            lex_solution.min_contact_normal_force;
+            qp_solution.min_contact_normal_force;
     }
     else
     {


### PR DESCRIPTION
## Summary
- Dense ADMM QP (`dense_qp.h`) with no third-party solver.
- `--wbc-full` contact forces come from that QP under a friction pyramid (`contact_wrench_qp.h`), falling back to the projected allocator if infeasible.
- Foothold preview jointly plans all N adjustments (`footstep_mpc.h`); the first step is applied and its planned `a_x` is the centroidal task.
- `real_trot_go2` without `--wbc-full` is still the 0.15 m/s baseline. Speed is not claimed. This is centroidal (6-DoF `M`), not 18-DoF inverse dynamics.

## Test plan
- `python3 tools/check_repo_hygiene.py`
- `ctest --test-dir example/cpp/build --output-on-failure` (18/18)