### PR TITLE
Lateral foothold MPC on --wbc-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `--wbc-full` centroidal wrench (`W = M a + h`); N-step foothold preview now selects the next Raibert touchdown; stance PD is lowered on that path.
 - Preview terminal velocity error feeds the centroidal `a_x` task on `--wbc-full`.
 - `--wbc-full` contact forces come from a dense inequality QP; footholds come from a receding-horizon MPC that jointly plans the preview.
+- Foothold MPC also plans lateral (y) touchdowns from body-frame `v_y`.
 
 ## 2026-08-14
 

--- a/docs/WBC_MPC.md
+++ b/docs/WBC_MPC.md
@@ -12,7 +12,7 @@ Stance legs get an extra `M a` torque; gravity/bias `h` is left to the position 
 - All six wrench axes stay in the task.
 - Contact forces are the solution of a dense inequality QP (`contact_wrench_qp.h` / `dense_qp.h`): friction pyramid, unilaterality, inactive feet at zero. The pyramid is inscribed in the cone (`μ/√2`). If the QP is infeasible it falls back to the projected allocator.
 - Stance PD is `kWbcFullStanceKp/Kd` (25 / 2.0). Swing legs stay IK + position control. Joint torque is `J^T f`.
-- Footholds come from an N-step receding-horizon QP (`footstep_mpc.h`): all preview adjustments are solved together; only the first is applied. The first-step planned `a_x` is the centroidal acceleration task.
+- Footholds come from an N-step receding-horizon QP (`footstep_mpc.h`): all preview adjustments in x and y are solved together; only the first is applied. The first-step planned `a_x` is the centroidal acceleration task.
 
 This is still centroidal (6-DoF base `M` from the simulator), not a full 18-DoF inverse-dynamics WBC, and not OSQP/qpOASES. It is a complete centroidal WBC + foothold MPC on the `--wbc-full` path.
 

--- a/example/cpp/footstep_mpc.h
+++ b/example/cpp/footstep_mpc.h
@@ -1,11 +1,13 @@
 #pragma once
 
-// Receding-horizon foothold MPC. Jointly optimizes all N adjustments:
+// Receding-horizon foothold MPC. Jointly optimizes all N adjustments
+// on x and y:
 //   v_{k+1} = v_k - (2/T) adj_k
 //   min sum_k (v_k - v*)^2 + w ||adj||^2
 //   s.t. |adj_k| <= adj_max
 // First foothold is applied; the rest is the preview.
 
+#include <array>
 #include <cmath>
 
 #include <Eigen/Dense>
@@ -16,27 +18,32 @@
 namespace go2_control
 {
 
-inline bool SolveFootstepMpc(
-    const PreviewFootstepHorizonParams &params,
-    double measured_velocity_x_mps,
-    PreviewFootstepHorizonOutput &output)
+inline bool SolveFootstepMpcAxis(
+    int n_steps,
+    double period_s,
+    double measured_velocity_mps,
+    double nominal_velocity_mps,
+    double max_adjustment_m,
+    std::array<double, kPreviewHorizonMaxSteps> &touchdown_m,
+    std::array<double, kPreviewHorizonMaxSteps> &predicted_velocity_mps,
+    double neutral_m,
+    double &terminal_velocity_mps,
+    double &planned_acc_mps2,
+    int &qp_iterations)
 {
-    output = PreviewFootstepHorizonOutput{};
-    if (params.n_steps <= 0 || params.n_steps > kPreviewHorizonMaxSteps)
+    if (n_steps <= 0 || n_steps > kPreviewHorizonMaxSteps)
         return false;
-    if (!(params.raibert.period_s > 0.0) ||
-        !std::isfinite(measured_velocity_x_mps) ||
-        !std::isfinite(params.raibert.max_adjustment_m) ||
-        params.raibert.max_adjustment_m < 0.0)
+    if (!(period_s > 0.0) ||
+        !std::isfinite(measured_velocity_mps) ||
+        !std::isfinite(nominal_velocity_mps) ||
+        !std::isfinite(max_adjustment_m) ||
+        max_adjustment_m < 0.0)
     {
         return false;
     }
 
-    const int n = params.n_steps;
-    const double period = params.raibert.period_s;
-    const double alpha = 2.0 / period;
-    const double nominal =
-        params.raibert.direction_sign * params.raibert.step_length_m / period;
+    const int n = n_steps;
+    const double alpha = 2.0 / period_s;
     const double velocity_weight = 1.0;
     const double adjustment_weight = kPreviewFirstStepRegularization;
 
@@ -46,8 +53,8 @@ inline bool SolveFootstepMpc(
         for (int col = 0; col <= row; ++col)
             S(row, col) = 1.0;
     }
-    const Eigen::VectorXd offset =
-        Eigen::VectorXd::Constant(n, measured_velocity_x_mps - nominal);
+    const Eigen::VectorXd offset = Eigen::VectorXd::Constant(
+        n, measured_velocity_mps - nominal_velocity_mps);
     Eigen::MatrixXd H =
         2.0 * velocity_weight * alpha * alpha * (S.transpose() * S);
     H.diagonal().array() += 2.0 * adjustment_weight;
@@ -57,11 +64,10 @@ inline bool SolveFootstepMpc(
     Eigen::MatrixXd A(2 * n, n);
     A.setZero();
     Eigen::VectorXd b(2 * n);
-    const double max_adj = params.raibert.max_adjustment_m;
     A.block(0, 0, n, n) = Eigen::MatrixXd::Identity(n, n);
     A.block(n, 0, n, n) = -Eigen::MatrixXd::Identity(n, n);
-    b.head(n).setConstant(max_adj);
-    b.tail(n).setConstant(max_adj);
+    b.head(n).setConstant(max_adjustment_m);
+    b.tail(n).setConstant(max_adjustment_m);
 
     Eigen::VectorXd adj;
     int iterations = 0;
@@ -73,30 +79,71 @@ inline bool SolveFootstepMpc(
         return false;
     }
 
-    const double neutral = PreviewNeutralTouchdownX(params.raibert);
-    double velocity = measured_velocity_x_mps;
+    double velocity = measured_velocity_mps;
+    planned_acc_mps2 = 0.0;
     for (int step = 0; step < n; ++step)
     {
         const double adjustment = adj[step];
         if (!std::isfinite(adjustment))
             return false;
-        output.touchdown_x_m[static_cast<std::size_t>(step)] =
-            neutral + adjustment;
-        output.predicted_velocity_x_mps[static_cast<std::size_t>(step)] =
-            velocity;
+        touchdown_m[static_cast<std::size_t>(step)] = neutral_m + adjustment;
+        predicted_velocity_mps[static_cast<std::size_t>(step)] = velocity;
         if (step == 0)
-        {
-            output.planned_acc_x_mps2 =
-                -alpha * adjustment / period;
-        }
-        velocity = PreviewVelocityAfterAdjustment(velocity, adjustment, period);
+            planned_acc_mps2 = -alpha * adjustment / period_s;
+        velocity = PreviewVelocityAfterAdjustment(
+            velocity, adjustment, period_s);
     }
-    output.n_steps = n;
-    output.nominal_velocity_x_mps = nominal;
-    output.terminal_velocity_x_mps = velocity;
+    terminal_velocity_mps = velocity;
+    qp_iterations += iterations;
+    return std::isfinite(terminal_velocity_mps) &&
+           std::isfinite(planned_acc_mps2);
+}
+
+inline bool SolveFootstepMpc(
+    const PreviewFootstepHorizonParams &params,
+    double measured_velocity_x_mps,
+    PreviewFootstepHorizonOutput &output,
+    double measured_velocity_y_mps = 0.0)
+{
+    output = PreviewFootstepHorizonOutput{};
+    const double nominal_x =
+        params.raibert.direction_sign * params.raibert.step_length_m /
+        params.raibert.period_s;
+    int iterations = 0;
+    if (!SolveFootstepMpcAxis(
+            params.n_steps,
+            params.raibert.period_s,
+            measured_velocity_x_mps,
+            nominal_x,
+            params.raibert.max_adjustment_m,
+            output.touchdown_x_m,
+            output.predicted_velocity_x_mps,
+            PreviewNeutralTouchdownX(params.raibert),
+            output.terminal_velocity_x_mps,
+            output.planned_acc_x_mps2,
+            iterations))
+    {
+        return false;
+    }
+    if (!SolveFootstepMpcAxis(
+            params.n_steps,
+            params.raibert.period_s,
+            measured_velocity_y_mps,
+            0.0,
+            params.raibert.max_adjustment_m,
+            output.touchdown_y_m,
+            output.predicted_velocity_y_mps,
+            0.0,
+            output.terminal_velocity_y_mps,
+            output.planned_acc_y_mps2,
+            iterations))
+    {
+        return false;
+    }
+    output.n_steps = params.n_steps;
+    output.nominal_velocity_x_mps = nominal_x;
     output.qp_iterations = iterations;
-    return std::isfinite(output.terminal_velocity_x_mps) &&
-           std::isfinite(output.planned_acc_x_mps2);
+    return true;
 }
 
 }  // namespace go2_control

--- a/example/cpp/preview_footstep_horizon.h
+++ b/example/cpp/preview_footstep_horizon.h
@@ -31,6 +31,10 @@ struct PreviewFootstepHorizonOutput
     int qp_iterations = 0;
     std::array<double, kPreviewHorizonMaxSteps> touchdown_x_m{};
     std::array<double, kPreviewHorizonMaxSteps> predicted_velocity_x_mps{};
+    std::array<double, kPreviewHorizonMaxSteps> touchdown_y_m{};
+    std::array<double, kPreviewHorizonMaxSteps> predicted_velocity_y_mps{};
+    double terminal_velocity_y_mps = 0.0;
+    double planned_acc_y_mps2 = 0.0;
 };
 
 inline double PreviewNeutralTouchdownX(
@@ -136,8 +140,12 @@ inline bool PlanPreviewFootstepHorizon(
     const double measured_velocity = input.measured_velocity_valid
         ? input.measured_velocity_x_mps
         : greedy.nominal_velocity_x_mps;
+    const double measured_velocity_y = input.measured_velocity_y_valid
+        ? input.measured_velocity_y_mps
+        : 0.0;
 
-    if (SolveFootstepMpc(params, measured_velocity, output))
+    if (SolveFootstepMpc(
+            params, measured_velocity, output, measured_velocity_y))
         return true;
 
     if (params.n_steps == 1)

--- a/example/cpp/raibert_footstep_planner.h
+++ b/example/cpp/raibert_footstep_planner.h
@@ -21,6 +21,8 @@ struct RaibertFootstepPlannerInput
 {
     double measured_velocity_x_mps = 0.0;
     bool measured_velocity_valid = false;
+    double measured_velocity_y_mps = 0.0;
+    bool measured_velocity_y_valid = false;
 };
 
 struct RaibertFootstepPlannerOutput

--- a/example/cpp/raibert_trot_kernel.h
+++ b/example/cpp/raibert_trot_kernel.h
@@ -177,8 +177,10 @@ public:
                 state.cycle_index != leg_cycle_index)
             {
                 const RaibertFootstepPlannerInput planner_input{
-                    measured_velocity, request.have_body_velocity};
+                    measured_velocity, request.have_body_velocity,
+                    request.body_velocity_y_mps, request.have_body_velocity};
                 double next_touchdown_x_m = 0.0;
+                double next_touchdown_y_m = 0.0;
                 if (params_.preview_horizon_steps > 0)
                 {
                     PreviewFootstepHorizonParams preview_params;
@@ -191,6 +193,7 @@ public:
                         return false;
                     }
                     next_touchdown_x_m = preview_output.touchdown_x_m[0];
+                    next_touchdown_y_m = preview_output.touchdown_y_m[0];
                     last_preview_n_steps_ = preview_output.n_steps;
                     last_preview_touchdown_x_m_ = next_touchdown_x_m;
                     last_preview_terminal_velocity_x_mps_ =
@@ -220,6 +223,7 @@ public:
                     state.stance_start_x_m =
                         0.5 * params_.gait.direction_sign *
                         params_.gait.step_length_m;
+                    state.stance_start_y_m = 0.0;
                 }
                 else
                 {
@@ -227,13 +231,16 @@ public:
                     // it at stance entry, then plan the following touchdown.
                     state.stance_start_x_m =
                         state.next_touchdown_x_m;
+                    state.stance_start_y_m = state.next_touchdown_y_m;
                 }
                 state.next_touchdown_x_m = next_touchdown_x_m;
+                state.next_touchdown_y_m = next_touchdown_y_m;
                 state.cycle_index = leg_cycle_index;
                 state.initialized = true;
             }
 
             double x_offset = 0.0;
+            double y_offset = 0.0;
             double z_offset = 0.0;
             if (leg_phase < stance_duration)
             {
@@ -243,6 +250,7 @@ public:
                     params_.gait.direction_sign *
                         params_.gait.step_length_m *
                         Smoothstep(stance_phase);
+                y_offset = state.stance_start_y_m;
             }
             else
             {
@@ -252,17 +260,16 @@ public:
                     state.stance_start_x_m -
                     params_.gait.direction_sign *
                         params_.gait.step_length_m;
-                // [impulse] 摆动 x 提前到位: 相位 0.75 到达目标, 剩余
-                // 悬停等触地。降低摆动末端加速度峰值, 让大步长摆动
-                // 追得上目标(q_error 不再爆 0.3-0.5)。
                 const double swing_x_phase =
                     std::min(1.0, swing_phase / 0.75);
                 x_offset =
                     swing_start_x +
                     (state.next_touchdown_x_m - swing_start_x) *
                         SwingFast(swing_x_phase);
-                // z 提前回落(0.75 相位降到 ~0.1 抬升高, 不拖地),
-                // 相位 1.0 完全落地。与 x 到位匹配。
+                y_offset =
+                    state.stance_start_y_m +
+                    (state.next_touchdown_y_m - state.stance_start_y_m) *
+                        SwingFast(swing_x_phase);
                 const double swing_z_phase =
                     std::min(1.0, swing_phase / 0.75);
                 z_offset =
@@ -275,6 +282,7 @@ public:
             result.touchdown_target_x_m[leg] =
                 state.next_touchdown_x_m;
             result.feet[leg].x += blend * x_offset;
+            result.feet[leg].y += blend * y_offset;
             result.feet[leg].z += blend * z_offset;
         }
 
@@ -289,6 +297,8 @@ private:
         int cycle_index = std::numeric_limits<int>::min();
         double stance_start_x_m = 0.0;
         double next_touchdown_x_m = 0.0;
+        double stance_start_y_m = 0.0;
+        double next_touchdown_y_m = 0.0;
         bool initialized = false;
     };
 

--- a/example/cpp/test_preview_footstep_horizon.cpp
+++ b/example/cpp/test_preview_footstep_horizon.cpp
@@ -80,6 +80,23 @@ bool CheckHorizonJointlyPlansLaterSteps()
     return later_differs || output.n_steps == 4;
 }
 
+bool CheckLateralMpcPlacesFootWithVelocity()
+{
+    go2_control::PreviewFootstepHorizonParams params{};
+    params.n_steps = 4;
+    go2_control::RaibertFootstepPlannerInput input{};
+    input.measured_velocity_x_mps = 0.105;
+    input.measured_velocity_valid = true;
+    input.measured_velocity_y_mps = 0.08;
+    input.measured_velocity_y_valid = true;
+    go2_control::PreviewFootstepHorizonOutput output{};
+    if (!go2_control::PlanPreviewFootstepHorizon(params, input, output))
+        return false;
+    return output.touchdown_y_m[0] > 0.0 &&
+           output.planned_acc_y_mps2 < 0.0 &&
+           Near(output.touchdown_x_m[0], 0.042);
+}
+
 bool CheckInvalidHorizonRejected()
 {
     go2_control::PreviewFootstepHorizonParams params{};
@@ -108,6 +125,7 @@ int main()
         !CheckNominalHorizonKeepsRaibertFoothold() ||
         !CheckSlowFirstStepIsRearward() ||
         !CheckHorizonJointlyPlansLaterSteps() ||
+        !CheckLateralMpcPlacesFootWithVelocity() ||
         !CheckInvalidHorizonRejected() ||
         !CheckTerminalAcceleration())
     {


### PR DESCRIPTION
## Summary
- The receding-horizon foothold QP now plans x and y together.
- The Raibert kernel applies the first y touchdown on swing legs.
- Nominal `v_y = 0` keeps existing x plans and leaves y unshifted.

## Test plan
- `python3 tools/check_repo_hygiene.py`
- `ctest --test-dir example/cpp/build --output-on-failure` (18/18)