### PR TITLE
Record walk vs --wbc-full speed; skip headless window wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Preview terminal velocity error feeds the centroidal `a_x` task on `--wbc-full`.
 - `--wbc-full` contact forces come from a dense inequality QP; footholds come from a receding-horizon MPC that jointly plans the preview.
 - Foothold MPC also plans lateral (y) touchdowns from body-frame `v_y`.
+- Headless `run_trot.sh` no longer waits up to 20 s for a MuJoCo window before starting the controller.
+- Same-gate walk vs `--wbc-full` speed audit recorded in `docs/WBC_MPC.md`: both failed the cycle-quality gate; `--wbc-full` was not faster.
 
 ## 2026-08-14
 

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -13,7 +13,7 @@ This repository records **model-based Go2 control in MuJoCo**, plus an Isaac Lab
 | Transitions | Smoothstep interpolation of 12 joint targets; gait amplitude ramps over 0.8 s from the stand pose |
 | Reliable cruise | about 0.15 m/s (`go2sim walk`); 0.18 m/s (`go2sim fast`) needs `--tau-limit 19` |
 | Beyond that | 0.21 m/s rejected under the recorded torque/quality gates |
-| WBC | incremental dynamics-informed components with position-control fallback, not a complete full-dynamics stack |
+| WBC | `--wbc-full` is centroidal QP + foothold MPC; same-gate audit vs 0.15 walk is in `docs/WBC_MPC.md` (not faster; both failed the quality gate in that session) |
 
 **Supported claim:** the sequenced task and a slow, measurable trot run in this simulator stack.
 

--- a/docs/WBC_MPC.md
+++ b/docs/WBC_MPC.md
@@ -30,6 +30,26 @@ Or trot-only:
 
 `--preview-horizon 0` after `--wbc-full` keeps the centroidal QP and turns the foothold MPC off.
 
-## Acceptance
+Headless `run_trot.sh` must not wait on a MuJoCo GLFW window. An xdotool search there blocks up to 20 s while physics runs without LowCmd, which is not part of the gait comparison.
 
-The gated 0.15 m/s trot is the comparison. This path is ahead of that baseline only if it walks faster without failing the same cycle-quality / torque gates. That measurement is not claimed yet.
+## Same-gate comparison (2026-08-15)
+
+Protocol (nominal `0.091/0.60 = 0.151667` m/s):
+
+```text
+--period 0.60 --duty 0.75 --foot-lift 0.020 --kp 63 --kd 2.8
+--kernel raibert-trot --raibert-velocity-gain 0.05 --raibert-max-adjustment 0.010
+--world-feedback-max 0.060 --world-feedback-slew 0.004 --wbc-primary
+--step-length 0.091 --headless
+```
+
+`walk` is that command. `full` adds `--wbc-full`. Speed is `analyze_locomotion_progress.py` on `motion_stage==2`. Raw CSVs stay in gitignored `_runs/`.
+
+| Arm | Gate | Cycles until reject | measured m/s | ratio vs 0.151667 | lateral drift m | Notes |
+|---|---|---|---|---|---|---|
+| `go2sim walk` | FAIL `q_error=0.293` at cycle 3 | 3 | 0.0866 | 0.57 | 0.0084 | 500 Hz wall; projected wrench satisfied 35/1202 ticks |
+| `go2sim full` | FAIL `q_error=0.292` at cycle 1 | 1 | 0.0499 | 0.33 | 0.0064 | QP wrench satisfied 0/600 ticks; residual ~8.7 |
+
+`--wbc-full` did not beat the 0.15 baseline under these gates. It rejected earlier and moved slower on the walking samples it produced.
+
+The same-host Aug 9 `go2sim walk` (same sim binary and scene hash, 64 cycles, quality pass) is not reproduced in this session: the Aug 13 local `real_trot_go2` also rejected at cycle 3 with the same first-cycle pitch (~3.8° vs historical ~0.7°) and world-ref `x≈-0.091` (historical `x≈-0.050`). That confounder is recorded; it is not used to claim a public-tree gait regression, and it is not used to claim that `--wbc-full` is faster.

--- a/example/cpp/scripts/run_trot.sh
+++ b/example/cpp/scripts/run_trot.sh
@@ -246,7 +246,12 @@ if [[ "$sim_ready" != true ]]; then
   exit 1
 fi
 
-activate_simulator_window
+# Headless has no GLFW window. Waiting on xdotool here lets the robot sag
+# under gravity for up to 20s before the controller starts, which trips the
+# cycle-quality gate. Only focus a window when the viewer is actually up.
+if [[ "$sim_headless" != true ]]; then
+  activate_simulator_window
+fi
 
 controller_status=0
 if [[ "$continuous_mode" == true ]]; then


### PR DESCRIPTION
Same-gate audit of `go2sim walk` vs `go2sim full` under the 0.15 m/s protocol.

- Headless `run_trot.sh` no longer waits up to 20s for a GLFW window that does not exist.
- Measured speeds and gate outcomes are in `docs/WBC_MPC.md`. `--wbc-full` did not beat the baseline; both arms failed the cycle-quality gate in this session.

Do not treat this as a speed claim.