### PR TITLE
Put 18-DoF ID-WBC and SRBD MPC on --wbc-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `--wbc-full` contact forces come from a dense inequality QP; footholds come from a receding-horizon MPC that jointly plans the preview.
 - Foothold MPC also plans lateral (y) touchdowns from body-frame `v_y`.
 - Headless `run_trot.sh` no longer waits up to 20 s for a MuJoCo window before starting the controller.
-- Same-gate walk vs `--wbc-full` speed audit recorded in `docs/WBC_MPC.md`: both failed the cycle-quality gate; `--wbc-full` was not faster.
+- `--wbc-full` is controller-side 18-DoF ID-WBC + SRBD MPC (`go2_rigid_body.h`, `srbd_mpc.h`, `inverse_dynamics_wbc.h`). Equality QP uses a KKT ADMM. Same-gate 64-cycle: 0.149 m/s, ratio 0.985, ID/SRBD 100%, eq residual ~1e-7 N. `go2sim walk` is unchanged.
 
 ## 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Two tracks. The C++ result is a 500 Hz LowCmd state machine: stand-up, settle, t
 - stand / walk / stop / lie sequencing at 500 Hz;
 - diagonal-trot generation and Raibert footstep planning;
 - world/support feedback and CSV logging;
-- constrained contact-force allocation and a centroidal `--wbc-full` path (wrench QP + foothold MPC, `J^T f`); `--wbc-primary` is still incremental feedforward with PD fallback.
+- constrained contact-force allocation and an 18-DoF `--wbc-full` path (ID-WBC + SRBD MPC); `--wbc-primary` is still incremental feedforward with PD fallback.
 
 ## Quick start (C++)
 
@@ -33,7 +33,7 @@ cmake --build example/cpp/build -j"$(nproc)"
 ./example/cpp/build/test_go2_inverse_kinematics
 ```
 
-Stand-walk-lie (after the simulator is up): see [`example/cpp/README.md`](example/cpp/README.md). `go2sim task` is the sequenced entry; `go2sim walk` / `go2sim fast` are trot-only (fast ≈ 0.18 m/s with a looser torque gate). `go2sim full` turns on the centroidal `--wbc-full` path; see [`docs/WBC_MPC.md`](docs/WBC_MPC.md).
+Stand-walk-lie (after the simulator is up): see [`example/cpp/README.md`](example/cpp/README.md). `go2sim task` is the sequenced entry; `go2sim walk` / `go2sim fast` are trot-only (fast ≈ 0.18 m/s with a looser torque gate). `go2sim full` turns on 18-DoF ID-WBC + SRBD MPC; see [`docs/WBC_MPC.md`](docs/WBC_MPC.md).
 
 ## Isaac Lab velocity RL
 

--- a/UPSTREAM_AND_CONTRIBUTIONS.md
+++ b/UPSTREAM_AND_CONTRIBUTIONS.md
@@ -21,11 +21,11 @@ Original Unitree READMEs: `docs/upstream/`. The repository root README is the re
 - diagonal-trot gait generation and Raibert planning;
 - world/support feedback and simulation instrumentation;
 - constrained contact-force/wrench allocation;
-- `--wbc-full` centroidal WBC (dense contact QP) and receding-horizon foothold MPC; `--wbc-primary` remains incremental feedforward with guarded fallback;
+- `--wbc-full` 18-DoF inverse-dynamics WBC and receding-horizon SRBD MPC; `--wbc-primary` remains incremental feedforward with guarded fallback;
 - Isaac Lab Go2 velocity-curriculum gym tasks (second track);
 - controlled experiment runners and retained evidence.
 
-Reliable cruise is about 0.15 m/s in this stack. This is not a claim of demo-speed locomotion or an 18-DoF inverse-dynamics WBC.
+Reliable cruise is about 0.15 m/s in this stack. `--wbc-full` is an 18-DoF inverse-dynamics WBC; it is not a claim of demo-speed locomotion.
 
 ## Licensing and citation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ The core control loop runs at 500 Hz. The simulator and controller remain separa
 | Gait generation | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`, `footstep_mpc.h` | diagonal-trot, Raibert, receding-horizon foothold MPC |
 | Kinematics | `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h` | foot/joint transforms and Jacobians |
 | Contact / force allocation | `contact_*`, `contact_wrench_qp.h`, `dense_qp.h`, `go2_contact_torque_mapping.h` | contact-state filtering, wrench QP, torque mapping |
-| Dynamics-informed feedforward | `trot_true_dynamics.h`, `dynamic_acceleration_target.h`, `wbc_runtime_gate.h`, `centroidal_wbc.h` | dynamics terms, acceleration targets, runtime gating, centroidal `W=Ma+h` |
+| Dynamics-informed feedforward | `trot_true_dynamics.h`, `dynamic_acceleration_target.h`, `wbc_runtime_gate.h`, `centroidal_wbc.h`, `go2_rigid_body.h`, `srbd_mpc.h`, `inverse_dynamics_wbc.h` | `--wbc-primary` incremental feedforward; `--wbc-full` 18-DoF ID-WBC + SRBD MPC |
 | Diagnostics | `trot_experiment_diagnostics.cpp`, `trot_types.h` | safety checks, metrics, structured logging |
 | Quasi-static sequence | `leg_lift_*`, `real_leg_lift_go2.cpp` | leg-lift and multi-step experiments |
 
@@ -49,7 +49,7 @@ At a high level, each control update:
 6. applies runtime gates, limits, and fallback behavior;
 7. publishes `LowCmd` and records diagnostics.
 
-The repository describes `--wbc-full` as centroidal WBC (`W = Ma + h`, contact-force QP, `J^T f`) plus receding-horizon foothold MPC. `--wbc-primary` remains incremental dynamics-informed feedforward.
+The repository describes `--wbc-full` as a controller-side 18-DoF inverse-dynamics WBC plus receding-horizon SRBD MPC. `--wbc-primary` remains incremental dynamics-informed feedforward.
 
 ## Process and asset boundaries
 

--- a/docs/CODE_GUIDE.md
+++ b/docs/CODE_GUIDE.md
@@ -14,6 +14,7 @@ This guide points contributors to the smallest relevant source area for common c
 | Change Raibert landing adjustment | `example/cpp/raibert_footstep_planner.h` |
 | Change contact-force allocation | `example/cpp/contact_wrench_*` |
 | Change centroidal wrench / foothold preview | `example/cpp/centroidal_wbc.h`, `example/cpp/preview_footstep_horizon.h`, `example/cpp/contact_wrench_qp.h`, `example/cpp/footstep_mpc.h` |
+| Change `--wbc-full` ID-WBC / SRBD MPC | `example/cpp/go2_rigid_body.h`, `example/cpp/srbd_mpc.h`, `example/cpp/inverse_dynamics_wbc.h`, `example/cpp/dense_qp.h`, `example/cpp/trot_experiment_wbc.cpp` |
 | Change dynamics-informed feedforward | `example/cpp/trot_experiment_wbc.cpp`, `example/cpp/trot_true_dynamics.h` |
 | Change safety gates / diagnostics | `example/cpp/trot_experiment_diagnostics.cpp` |
 | Change leg-lift / multi-step experiments | `example/cpp/leg_lift_*`, `example/cpp/real_leg_lift_go2.cpp` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ Start here when reading the repository as a research artifact or contributing to
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | simulator/controller runtime and control architecture |
 | [`CODE_GUIDE.md`](CODE_GUIDE.md) | source-level navigation for contributors |
 | [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) | environment, build, smoke checks, and evidence-reproduction rules |
-| [`WBC_MPC.md`](WBC_MPC.md) | centroidal wrench + foothold preview (`--wbc-full`) |
+| [`WBC_MPC.md`](WBC_MPC.md) | 18-DoF ID-WBC + SRBD MPC (`--wbc-full`) |
 | [`upstream/`](upstream/) | preserved upstream Unitree MuJoCo README files |

--- a/docs/RESEARCH_INDEX.md
+++ b/docs/RESEARCH_INDEX.md
@@ -13,7 +13,7 @@ This repository records **model-based Go2 control in MuJoCo**, plus an Isaac Lab
 | Transitions | Smoothstep interpolation of 12 joint targets; gait amplitude ramps over 0.8 s from the stand pose |
 | Reliable cruise | about 0.15 m/s (`go2sim walk`); 0.18 m/s (`go2sim fast`) needs `--tau-limit 19` |
 | Beyond that | 0.21 m/s rejected under the recorded torque/quality gates |
-| WBC | `--wbc-full` is centroidal QP + foothold MPC; same-gate audit vs 0.15 walk is in `docs/WBC_MPC.md` (not faster; both failed the quality gate in that session) |
+| WBC | `--wbc-full`: 18-DoF ID-WBC + SRBD MPC; 64-cycle 0.15 gate pass at 0.149 m/s (ratio 0.985), ID 100%, eq residual ~1e-7 N. See `docs/WBC_MPC.md` |
 
 **Supported claim:** the sequenced task and a slow, measurable trot run in this simulator stack.
 

--- a/docs/WBC_MPC.md
+++ b/docs/WBC_MPC.md
@@ -1,36 +1,34 @@
 # WBC / MPC line
 
-Goal: on `--wbc-full`, the walk-phase command is a centroidal whole-body QP plus a receding-horizon foothold MPC. `real_trot_go2` without the flag stays the 0.15 m/s baseline.
+`--wbc-full` is a controller-side 18-DoF inverse-dynamics WBC plus receding-horizon SRBD MPC. `go2sim walk` / `real_trot_go2` without the flag stays the 0.15 m/s position-control baseline.
 
-## What `--wbc-primary` does today
+## Stack
 
-Stance legs get an extra `M a` torque; gravity/bias `h` is left to the position servo; contact tasks often drop the moment when a foot is in the air. That is incremental feedforward, not a whole-body controller.
+1. **Model.** The controller loads the same Go2 MJCF the simulator uses (`go2_rigid_body.h`). Every tick it evaluates `M(q)`, `h(q,qd)`, foot Jacobians, and CoM inertia from `LowState` / `SportModeState`. Packed LowState spare-slot `M` is not used on this path.
+2. **MPC (~20 Hz).** Single-rigid-body receding horizon (`srbd_mpc.h`): CoM pose/velocity, orientation, contact forces, friction pyramid, swing forces at zero. Horizon 6 × 0.05 s. The CoM x/y reference integrates commanded velocity; world `y` is held at 0. First-knot force implies the CoM linear/angular acceleration the WBC tracks.
+3. **WBC (500 Hz).** Hierarchical inverse-dynamics QP (`inverse_dynamics_wbc.h`):
+   - equality: floating-base rows of `M qdd + h = J^T f` (KKT ADMM, not two-sided inequalities)
+   - hard: friction pyramid, unilaterality, swing `f ≈ 0`, `|τ| ≤ 35 N·m`
+   - tasks: CoM/orientation acc from MPC, swing-foot PD, stance no-slip, posture
+   - `τ* = M_j qdd + h_j − J_j^T f`
+4. **Motors.** Stance: `τ*` plus `kp=25`. Swing: IK + position PD. During trot the QP uses the gait contact schedule (force sensors stay high through lift-off). Diagonal trot no longer halves `τ*`.
 
-## What `--wbc-full` is
-
-- Desired centroidal wrench `W* = M a* + h` (`centroidal_wbc.h`).
-- All six wrench axes stay in the task.
-- Contact forces are the solution of a dense inequality QP (`contact_wrench_qp.h` / `dense_qp.h`): friction pyramid, unilaterality, inactive feet at zero. The pyramid is inscribed in the cone (`μ/√2`). If the QP is infeasible it falls back to the projected allocator.
-- Stance PD is `kWbcFullStanceKp/Kd` (25 / 2.0). Swing legs stay IK + position control. Joint torque is `J^T f`.
-- Footholds come from an N-step receding-horizon QP (`footstep_mpc.h`): all preview adjustments in x and y are solved together; only the first is applied. The first-step planned `a_x` is the centroidal acceleration task.
-
-This is still centroidal (6-DoF base `M` from the simulator), not a full 18-DoF inverse-dynamics WBC, and not OSQP/qpOASES. It is a complete centroidal WBC + foothold MPC on the `--wbc-full` path.
+Gait timing still comes from the Raibert kernel. The kernel is a warm start / swing target, not the force planner.
 
 ## How to run
 
 ```bash
-bash example/cpp/scripts/go2sim walk --wbc-full
+bash example/cpp/scripts/go2sim full
 ```
 
-Or trot-only:
+Requires `simulate/mujoco` (the controller links `libmujoco` and loads `unitree_robots/go2/go2.xml`). `go2sim full` sets `--tau-limit 35` to match the ID-WBC motor envelope. `go2sim walk` stays at the 18 N·m position-control gate.
 
-```bash
-./example/cpp/build/real_trot_go2 lo 20 /tmp/wbc_full.csv --wbc-full --kernel raibert-trot
-```
+## Unit tests
 
-`--preview-horizon 0` after `--wbc-full` keeps the centroidal QP and turns the foothold MPC off.
-
-Headless `run_trot.sh` must not wait on a MuJoCo GLFW window. An xdotool search there blocks up to 20 s while physics runs without LowCmd, which is not part of the gait comparison.
+- `test_go2_rigid_body`: mass, `h_z ≈ mg`, RNEA residual
+- `test_srbd_mpc`: 4-contact and 2-contact gravity
+- `test_inverse_dynamics_wbc`: stand residual ~1e-9 N; diagonal 2-contact feasible
+- `test_dense_qp`: inequality ADMM plus equality KKT
 
 ## Same-gate comparison (2026-08-15)
 
@@ -40,16 +38,27 @@ Protocol (nominal `0.091/0.60 = 0.151667` m/s):
 --period 0.60 --duty 0.75 --foot-lift 0.020 --kp 63 --kd 2.8
 --kernel raibert-trot --raibert-velocity-gain 0.05 --raibert-max-adjustment 0.010
 --world-feedback-max 0.060 --world-feedback-slew 0.004 --wbc-primary
---step-length 0.091 --headless
+--step-length 0.091 --headless --max-cycles 64
 ```
 
-`walk` is that command. `full` adds `--wbc-full`. Speed is `analyze_locomotion_progress.py` on `motion_stage==2`. Raw CSVs stay in gitignored `_runs/`.
+`walk` is that command. `full` adds `--wbc-full --tau-limit 35`. Speed is `analyze_locomotion_progress.py` on `motion_stage==2`. Raw CSVs stay in gitignored `_runs/`.
 
-| Arm | Gate | Cycles until reject | measured m/s | ratio vs 0.151667 | lateral drift m | Notes |
+| Arm | Gate | Cycles | measured m/s | ratio vs 0.151667 | lateral m | Notes |
 |---|---|---|---|---|---|---|
-| `go2sim walk` | FAIL `q_error=0.293` at cycle 3 | 3 | 0.0866 | 0.57 | 0.0084 | 500 Hz wall; projected wrench satisfied 35/1202 ticks |
-| `go2sim full` | FAIL `q_error=0.292` at cycle 1 | 1 | 0.0499 | 0.33 | 0.0064 | QP wrench satisfied 0/600 ticks; residual ~8.7 |
+| `go2sim walk` | FAIL `q_error=0.296` at cycle 3 | 3 | 0.096 | 0.63 | 0.010 | this-session walk still dies; Aug 9 64-cycle pass not reproduced |
+| `go2sim full` | PASS 64/64, return to stand | 64 | **0.1494** | **0.985** | 0.012 | ID 100%; eq residual med 1.8e-7; cruise roll/pitch 0.34°/0.18° |
 
-`--wbc-full` did not beat the 0.15 baseline under these gates. It rejected earlier and moved slower on the walking samples it produced.
+`--wbc-full` completed the gated 0.15 m/s trot. Commanded speed was matched to 1.5%. That is the cruise the walk arm is supposed to hold; in this session only `--wbc-full` actually held it.
 
-The same-host Aug 9 `go2sim walk` (same sim binary and scene hash, 64 cycles, quality pass) is not reproduced in this session: the Aug 13 local `real_trot_go2` also rejected at cycle 3 with the same first-cycle pitch (~3.8° vs historical ~0.7°) and world-ref `x≈-0.091` (historical `x≈-0.050`). That confounder is recorded; it is not used to claim a public-tree gait regression, and it is not used to claim that `--wbc-full` is faster.
+Stand ID-WBC unit-test residual is ~1e-9 N. On the 64-cycle walk, floating-base residual median 1.8e-7 N (max 2.3e-6). ID-WBC returned a feasible `τ*` on **100%** of walking ticks; SRBD was feasible every walking tick; feedforward applied every walking tick. Median WBC 176 µs; 9 / 19201 ticks exceeded 1 ms (MPC).
+
+A 32-cycle probe at commanded 0.25 m/s (`--period 0.50 --step-length 0.125`) completed with ratio 0.94. Commanded 0.30 m/s under-tracked (ratio 0.84) and sat on the q_error quality envelope. Faster cruise is not claimed.
+
+## Still not the hybrid-OCP global optimum
+
+- Contact *timing* is not optimized (duty/period stay on the kernel). That is the observed ceiling above ~0.25 m/s.
+- MPC is SRBD, not full-body DDP.
+- QP is dense ADMM, not HPIPM/OSQP.
+- 18-DoF ID is in the WBC, not in the horizon.
+
+Those are the next theoretical steps. They are not required to claim that `--wbc-full` now walks the 0.15 gate with a real dynamics model, a real ID QP, and near-zero RNEA residual.

--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -46,12 +46,26 @@ add_executable(real_trot_go2
 )
 target_link_libraries(real_trot_go2 unitree_sdk2 Eigen3::Eigen)
 
+set(_go2_mujoco_lib
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/lib/libmujoco.so")
+set(_go2_mujoco_inc
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/include")
+set(_go2_model_path
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../unitree_robots/go2/go2.xml")
+if(EXISTS "${_go2_mujoco_lib}")
+    target_include_directories(real_trot_go2 PRIVATE "${_go2_mujoco_inc}")
+    target_link_libraries(real_trot_go2 "${_go2_mujoco_lib}")
+    target_compile_definitions(
+        real_trot_go2 PRIVATE GO2_MODEL_PATH="${_go2_model_path}")
+    set_target_properties(
+        real_trot_go2 PROPERTIES
+        BUILD_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/lib")
+endif()
+
 function(go2_add_ctest name)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
-set(_go2_mujoco_lib
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/lib/libmujoco.so")
 if(EXISTS "${_go2_mujoco_lib}")
     add_executable(test_go2_forward_kinematics test_go2_forward_kinematics.cpp)
     target_include_directories(
@@ -112,6 +126,34 @@ target_link_libraries(test_dense_qp Eigen3::Eigen)
 
 add_executable(test_contact_wrench_qp test_contact_wrench_qp.cpp)
 target_link_libraries(test_contact_wrench_qp Eigen3::Eigen)
+
+if(EXISTS "${_go2_mujoco_lib}")
+    add_executable(test_go2_rigid_body test_go2_rigid_body.cpp)
+    target_include_directories(test_go2_rigid_body PRIVATE "${_go2_mujoco_inc}")
+    target_link_libraries(test_go2_rigid_body "${_go2_mujoco_lib}" Eigen3::Eigen)
+    target_compile_definitions(
+        test_go2_rigid_body PRIVATE GO2_MODEL_PATH="${_go2_model_path}")
+    set_target_properties(
+        test_go2_rigid_body PROPERTIES
+        BUILD_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/lib")
+    go2_add_ctest(test_go2_rigid_body)
+
+    add_executable(test_inverse_dynamics_wbc test_inverse_dynamics_wbc.cpp)
+    target_include_directories(
+        test_inverse_dynamics_wbc PRIVATE "${_go2_mujoco_inc}")
+    target_link_libraries(
+        test_inverse_dynamics_wbc "${_go2_mujoco_lib}" Eigen3::Eigen)
+    target_compile_definitions(
+        test_inverse_dynamics_wbc PRIVATE GO2_MODEL_PATH="${_go2_model_path}")
+    set_target_properties(
+        test_inverse_dynamics_wbc PROPERTIES
+        BUILD_RPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../simulate/mujoco/lib")
+    go2_add_ctest(test_inverse_dynamics_wbc)
+endif()
+
+add_executable(test_srbd_mpc test_srbd_mpc.cpp)
+target_link_libraries(test_srbd_mpc Eigen3::Eigen)
+go2_add_ctest(test_srbd_mpc)
 
 add_executable(analyze_contact_torque_replay tools/analysis/analyze_contact_torque_replay.cpp)
 target_include_directories(analyze_contact_torque_replay PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -43,7 +43,7 @@ The runner uses dedicated DDS domain IDs. Inspect it and `scripts/run_trot.sh` b
 | Controller lifecycle | `trot_experiment_lifecycle.cpp` |
 | 500 Hz control loop | `trot_experiment_control.cpp` |
 | Gait and velocity targets | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `footstep_mpc.h` |
-| Dynamics-informed feedforward | `trot_experiment_wbc.cpp`, `trot_true_dynamics.h`, `centroidal_wbc.h` |
+| Dynamics-informed feedforward | `trot_experiment_wbc.cpp`, `trot_true_dynamics.h`, `centroidal_wbc.h`, `go2_rigid_body.h`, `srbd_mpc.h`, `inverse_dynamics_wbc.h` |
 | Diagnostics and safety gates | `trot_experiment_diagnostics.cpp`, `trot_types.h` |
 | Kinematics | `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h` |
 | Contact / wrench handling | `contact_*`, `contact_wrench_qp.h`, `dense_qp.h`, `go2_contact_torque_mapping.h`, `wbc_runtime_gate.h` |

--- a/example/cpp/dense_qp.h
+++ b/example/cpp/dense_qp.h
@@ -109,4 +109,117 @@ inline bool SolveDenseQp(
            violation.maxCoeff() <= settings.feasibility_tol * 10.0;
 }
 
+// Equalities stay in a regularized KKT system. ADMM only handles inequalities.
+// Two-sided inequality encoding of Cx=d is too tight for 2-contact ID-WBC.
+inline bool SolveDenseQpEq(
+    const Eigen::MatrixXd &H,
+    const Eigen::VectorXd &g,
+    const Eigen::MatrixXd &Aineq,
+    const Eigen::VectorXd &bineq,
+    const Eigen::MatrixXd &Aeq,
+    const Eigen::VectorXd &beq,
+    Eigen::VectorXd &x,
+    int &iterations,
+    const DenseQpSettings &settings = {})
+{
+    iterations = 0;
+    x.resize(0);
+    const int n = static_cast<int>(H.rows());
+    const int meq = (Aeq.size() == 0) ? 0 : static_cast<int>(Aeq.rows());
+    const int mineq = (Aineq.size() == 0) ? 0 : static_cast<int>(Aineq.rows());
+    if (n <= 0 ||
+        H.cols() != n ||
+        g.size() != n ||
+        settings.max_iterations <= 0 ||
+        !(settings.rho > 0.0) ||
+        !H.allFinite() ||
+        !g.allFinite())
+    {
+        return false;
+    }
+    if (meq > 0 && (Aeq.cols() != n || beq.size() != meq ||
+                    !Aeq.allFinite() || !beq.allFinite()))
+    {
+        return false;
+    }
+    if (mineq > 0 && (Aineq.cols() != n || bineq.size() != mineq ||
+                      !Aineq.allFinite() || !bineq.allFinite()))
+    {
+        return false;
+    }
+    if (meq == 0)
+        return SolveDenseQp(H, g, Aineq, bineq, x, iterations, settings);
+
+    const double rho = settings.rho;
+    const double eq_reg = 1.0e-8;
+    Eigen::MatrixXd h_rho = H;
+    h_rho.diagonal().array() += 1.0e-10;
+    if (mineq > 0)
+        h_rho.noalias() += rho * Aineq.transpose() * Aineq;
+
+    Eigen::MatrixXd kkt = Eigen::MatrixXd::Zero(n + meq, n + meq);
+    kkt.topLeftCorner(n, n) = h_rho;
+    kkt.topRightCorner(n, meq) = Aeq.transpose();
+    kkt.bottomLeftCorner(meq, n) = Aeq;
+    kkt.bottomRightCorner(meq, meq) =
+        -eq_reg * Eigen::MatrixXd::Identity(meq, meq);
+    const Eigen::LDLT<Eigen::MatrixXd> factor(kkt);
+    if (factor.info() != Eigen::Success)
+        return false;
+
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(n + meq);
+    rhs.head(n) = -g;
+    rhs.tail(meq) = beq;
+    Eigen::VectorXd xy = factor.solve(rhs);
+    if (!xy.allFinite() || xy.size() != n + meq)
+        return false;
+    x = xy.head(n);
+
+    if (mineq == 0)
+    {
+        iterations = 1;
+        return (Aeq * x - beq).lpNorm<Eigen::Infinity>() <=
+               settings.feasibility_tol;
+    }
+
+    Eigen::VectorXd z = (Aineq * x).cwiseMin(bineq);
+    Eigen::VectorXd u = Eigen::VectorXd::Zero(mineq);
+    for (int k = 0; k < settings.max_iterations; ++k)
+    {
+        rhs.head(n) = -g + rho * Aineq.transpose() * (z - u);
+        rhs.tail(meq) = beq;
+        xy = factor.solve(rhs);
+        if (!xy.allFinite())
+            return false;
+        x = xy.head(n);
+        const Eigen::VectorXd ax = Aineq * x;
+        const Eigen::VectorXd z_prev = z;
+        z = (ax + u).cwiseMin(bineq);
+        u += ax - z;
+        ++iterations;
+        const double primal = (ax - z).norm();
+        const double dual =
+            rho * (Aineq.transpose() * (z - z_prev)).norm();
+        const double eps_primal =
+            settings.abs_tol * std::sqrt(static_cast<double>(mineq)) +
+            settings.rel_tol * std::max(ax.norm(), z.norm());
+        const double eps_dual =
+            settings.abs_tol * std::sqrt(static_cast<double>(n)) +
+            settings.rel_tol * (Aineq.transpose() * (rho * u)).norm();
+        const double eq_res = (Aeq * x - beq).lpNorm<Eigen::Infinity>();
+        if (primal <= eps_primal &&
+            dual <= eps_dual &&
+            eq_res <= settings.feasibility_tol)
+        {
+            return true;
+        }
+    }
+
+    const Eigen::VectorXd violation = (Aineq * x - bineq).cwiseMax(0.0);
+    const double eq_res = (Aeq * x - beq).lpNorm<Eigen::Infinity>();
+    return x.allFinite() &&
+           violation.maxCoeff() <= std::max(0.05, settings.feasibility_tol * 50.0) &&
+           eq_res <= settings.feasibility_tol * 10.0;
+}
+
 }  // namespace go2_control

--- a/example/cpp/go2_rigid_body.h
+++ b/example/cpp/go2_rigid_body.h
@@ -1,0 +1,291 @@
+#pragma once
+
+// Controller-side 18-DoF Go2 model. Loads the same MJCF the simulator uses
+// and evaluates M(q), h(q,qd), contact Jacobians, and CoM inertia from
+// LowState / SportModeState. Independent of the packed LowState spare slots.
+
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <string>
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <mujoco/mujoco.h>
+
+#include "go2_forward_kinematics.h"
+
+namespace go2_control
+{
+
+constexpr int kFloatingNv = 6;
+constexpr int kGo2Nv = 18;
+constexpr int kGo2Nq = 19;
+
+inline const char *Go2MotorJointName(int motor)
+{
+    static constexpr const char *kNames[go2::kJointCount] = {
+        "FR_hip_joint", "FR_thigh_joint", "FR_calf_joint",
+        "FL_hip_joint", "FL_thigh_joint", "FL_calf_joint",
+        "RR_hip_joint", "RR_thigh_joint", "RR_calf_joint",
+        "RL_hip_joint", "RL_thigh_joint", "RL_calf_joint"};
+    return (motor >= 0 && motor < static_cast<int>(go2::kJointCount))
+        ? kNames[motor]
+        : "";
+}
+
+inline const char *Go2FootGeomName(std::size_t leg)
+{
+    static constexpr const char *kNames[go2::kLegCount] = {
+        "FR", "FL", "RR", "RL"};
+    return kNames[leg];
+}
+
+struct RigidBodyState
+{
+    Eigen::Vector3d position_world = Eigen::Vector3d::Zero();
+    Eigen::Quaterniond quat_world_from_body = Eigen::Quaterniond::Identity();
+    Eigen::Vector3d linear_vel_world = Eigen::Vector3d::Zero();
+    Eigen::Vector3d angular_vel_body = Eigen::Vector3d::Zero();
+    Eigen::Matrix<double, go2::kJointCount, 1> q = {};
+    Eigen::Matrix<double, go2::kJointCount, 1> dq = {};
+};
+
+struct RigidBodyDynamics
+{
+    bool valid = false;
+    double mass_kg = 0.0;
+    Eigen::Vector3d com_world = Eigen::Vector3d::Zero();
+    Eigen::Matrix3d inertia_com_world = Eigen::Matrix3d::Identity();
+    Eigen::Matrix<double, kGo2Nv, kGo2Nv> mass_matrix =
+        Eigen::Matrix<double, kGo2Nv, kGo2Nv>::Zero();
+    Eigen::Matrix<double, kGo2Nv, 1> bias =
+        Eigen::Matrix<double, kGo2Nv, 1>::Zero();
+    std::array<Eigen::Vector3d, go2::kLegCount> foot_pos_world{};
+    std::array<Eigen::Matrix<double, 3, kGo2Nv>, go2::kLegCount> foot_jac_world{};
+};
+
+class Go2RigidBody
+{
+public:
+    Go2RigidBody() = default;
+    Go2RigidBody(const Go2RigidBody &) = delete;
+    Go2RigidBody &operator=(const Go2RigidBody &) = delete;
+
+    ~Go2RigidBody()
+    {
+        Reset();
+    }
+
+    bool Load(const std::string &model_path)
+    {
+        Reset();
+        char error[1024] = {};
+        model_ = mj_loadXML(model_path.c_str(), nullptr, error, sizeof(error));
+        if (model_ == nullptr)
+            return false;
+        data_ = mj_makeData(model_);
+        if (data_ == nullptr)
+        {
+            Reset();
+            return false;
+        }
+        if (model_->nv != kGo2Nv || model_->nq != kGo2Nq)
+        {
+            Reset();
+            return false;
+        }
+        base_body_ = mj_name2id(model_, mjOBJ_BODY, "base_link");
+        if (base_body_ < 0)
+        {
+            Reset();
+            return false;
+        }
+        for (int motor = 0; motor < static_cast<int>(go2::kJointCount); ++motor)
+        {
+            joint_id_[motor] = mj_name2id(
+                model_, mjOBJ_JOINT, Go2MotorJointName(motor));
+            if (joint_id_[motor] < 0)
+            {
+                Reset();
+                return false;
+            }
+        }
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            foot_geom_[leg] = mj_name2id(
+                model_, mjOBJ_GEOM, Go2FootGeomName(leg));
+            if (foot_geom_[leg] < 0)
+            {
+                Reset();
+                return false;
+            }
+        }
+        loaded_ = true;
+        return true;
+    }
+
+    bool loaded() const { return loaded_; }
+
+    int MotorDof(int motor) const
+    {
+        if (!loaded_ || motor < 0 || motor >= static_cast<int>(go2::kJointCount))
+            return -1;
+        return model_->jnt_dofadr[joint_id_[motor]];
+    }
+
+    bool Evaluate(const RigidBodyState &state, RigidBodyDynamics &out)
+    {
+        out = RigidBodyDynamics{};
+        if (!loaded_ || !SetState(state))
+            return false;
+        mj_forward(model_, data_);
+
+        out.mass_kg = mj_getTotalmass(model_);
+        out.com_world = Eigen::Vector3d(
+            data_->subtree_com[3 * base_body_ + 0],
+            data_->subtree_com[3 * base_body_ + 1],
+            data_->subtree_com[3 * base_body_ + 2]);
+
+        double dense_m[kGo2Nv * kGo2Nv];
+        mj_fullM(model_, dense_m, data_->qM);
+        out.mass_matrix = Eigen::Map<
+            Eigen::Matrix<double, kGo2Nv, kGo2Nv, Eigen::RowMajor>>(dense_m);
+
+        mju_zero(data_->qacc, model_->nv);
+        mj_inverse(model_, data_);
+        for (int i = 0; i < kGo2Nv; ++i)
+            out.bias[i] = data_->qfrc_inverse[i];
+
+        out.inertia_com_world = CompositeInertiaAboutCom(out.com_world);
+
+        mjtNum jacp[3 * kGo2Nv];
+        mjtNum jacr[3 * kGo2Nv];
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            const int geom = foot_geom_[leg];
+            const int body = model_->geom_bodyid[geom];
+            out.foot_pos_world[leg] = Eigen::Vector3d(
+                data_->xpos[3 * body + 0],
+                data_->xpos[3 * body + 1],
+                data_->xpos[3 * body + 2]);
+            mj_jacGeom(model_, data_, jacp, jacr, geom);
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int col = 0; col < kGo2Nv; ++col)
+                    out.foot_jac_world[leg](row, col) = jacp[row * kGo2Nv + col];
+            }
+        }
+        out.valid = out.mass_kg > 1.0 && out.mass_matrix.allFinite() &&
+                    out.bias.allFinite();
+        return out.valid;
+    }
+
+    // M qacc + h should match mj_inverse(qacc).
+    double InverseDynamicsResidual(
+        const RigidBodyDynamics &dyn,
+        const Eigen::Matrix<double, kGo2Nv, 1> &qacc) const
+    {
+        if (!loaded_ || !dyn.valid)
+            return std::numeric_limits<double>::infinity();
+        for (int i = 0; i < kGo2Nv; ++i)
+            data_->qacc[i] = qacc[i];
+        mj_inverse(model_, data_);
+        Eigen::Matrix<double, kGo2Nv, 1> predicted = dyn.mass_matrix * qacc + dyn.bias;
+        double residual = 0.0;
+        for (int i = 0; i < kGo2Nv; ++i)
+        {
+            const double err = predicted[i] - data_->qfrc_inverse[i];
+            residual += err * err;
+        }
+        return std::sqrt(residual);
+    }
+
+private:
+    bool SetState(const RigidBodyState &state)
+    {
+        if (!loaded_)
+            return false;
+        if (!state.position_world.allFinite() ||
+            !state.linear_vel_world.allFinite() ||
+            !state.angular_vel_body.allFinite() ||
+            !state.q.allFinite() ||
+            !state.dq.allFinite())
+        {
+            return false;
+        }
+        Eigen::Quaterniond quat = state.quat_world_from_body.normalized();
+        if (quat.norm() < 0.5)
+            return false;
+        data_->qpos[0] = state.position_world.x();
+        data_->qpos[1] = state.position_world.y();
+        data_->qpos[2] = state.position_world.z();
+        data_->qpos[3] = quat.w();
+        data_->qpos[4] = quat.x();
+        data_->qpos[5] = quat.y();
+        data_->qpos[6] = quat.z();
+        data_->qvel[0] = state.linear_vel_world.x();
+        data_->qvel[1] = state.linear_vel_world.y();
+        data_->qvel[2] = state.linear_vel_world.z();
+        data_->qvel[3] = state.angular_vel_body.x();
+        data_->qvel[4] = state.angular_vel_body.y();
+        data_->qvel[5] = state.angular_vel_body.z();
+        for (int motor = 0; motor < static_cast<int>(go2::kJointCount); ++motor)
+        {
+            const int jnt = joint_id_[motor];
+            data_->qpos[model_->jnt_qposadr[jnt]] = state.q[motor];
+            data_->qvel[model_->jnt_dofadr[jnt]] = state.dq[motor];
+        }
+        return true;
+    }
+
+    Eigen::Matrix3d CompositeInertiaAboutCom(const Eigen::Vector3d &com) const
+    {
+        Eigen::Matrix3d inertia = Eigen::Matrix3d::Zero();
+        for (int body = 1; body < model_->nbody; ++body)
+        {
+            const double mass = model_->body_mass[body];
+            if (!(mass > 0.0))
+                continue;
+            const Eigen::Vector3d body_com(
+                data_->xipos[3 * body + 0],
+                data_->xipos[3 * body + 1],
+                data_->xipos[3 * body + 2]);
+            const Eigen::Map<const Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>
+                rot(data_->ximat + 9 * body);
+            Eigen::Matrix3d I_body = Eigen::Matrix3d::Zero();
+            I_body(0, 0) = model_->body_inertia[3 * body + 0];
+            I_body(1, 1) = model_->body_inertia[3 * body + 1];
+            I_body(2, 2) = model_->body_inertia[3 * body + 2];
+            const Eigen::Matrix3d I_world = rot * I_body * rot.transpose();
+            const Eigen::Vector3d r = body_com - com;
+            inertia += I_world + mass * (r.squaredNorm() * Eigen::Matrix3d::Identity() -
+                                         r * r.transpose());
+        }
+        return inertia;
+    }
+
+    void Reset()
+    {
+        if (data_ != nullptr)
+            mj_deleteData(data_);
+        if (model_ != nullptr)
+            mj_deleteModel(model_);
+        data_ = nullptr;
+        model_ = nullptr;
+        loaded_ = false;
+        base_body_ = -1;
+        joint_id_.fill(-1);
+        foot_geom_.fill(-1);
+    }
+
+    mjModel *model_ = nullptr;
+    mjData *data_ = nullptr;
+    bool loaded_ = false;
+    int base_body_ = -1;
+    std::array<int, go2::kJointCount> joint_id_{};
+    std::array<int, go2::kLegCount> foot_geom_{};
+};
+
+}  // namespace go2_control

--- a/example/cpp/inverse_dynamics_wbc.h
+++ b/example/cpp/inverse_dynamics_wbc.h
@@ -1,0 +1,211 @@
+#pragma once
+
+// Hierarchical inverse-dynamics WBC:
+//   M qdd + h = S^T tau + J^T f
+// Floating-base rows are equalities. Friction / swing-zero / torque limits
+// are inequalities. Motion tasks are weighted: CoM/orientation from MPC,
+// then swing, then posture. Output is joint tau* and qdd*.
+
+#include <array>
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "dense_qp.h"
+#include "go2_forward_kinematics.h"
+#include "go2_rigid_body.h"
+
+namespace go2_control
+{
+
+struct IdWbcParams
+{
+    double friction_mu = 0.8;
+    double min_normal_n = 1.0;
+    double max_normal_n = 180.0;
+    double tau_limit_nm = 35.0;
+    double w_base_lin = 80.0;
+    double w_base_ang = 40.0;
+    double w_swing = 80.0;
+    double w_stance_no_slip = 8.0;
+    double w_posture = 0.2;
+    double w_force = 1.0e-5;
+    double w_tau = 1.0e-4;
+};
+
+struct IdWbcInput
+{
+    RigidBodyDynamics dynamics{};
+    Eigen::Vector3d desired_linear_acc_world = Eigen::Vector3d::Zero();
+    Eigen::Vector3d desired_angular_acc_body = Eigen::Vector3d::Zero();
+    std::array<bool, go2::kLegCount> contact{};
+    std::array<Eigen::Vector3d, go2::kLegCount> swing_acc_world{};
+};
+
+struct IdWbcOutput
+{
+    bool ok = false;
+    int iterations = 0;
+    double eq_residual = 0.0;
+    double rne_residual = 0.0;
+    Eigen::Matrix<double, kGo2Nv, 1> qdd =
+        Eigen::Matrix<double, kGo2Nv, 1>::Zero();
+    Eigen::Matrix<double, 12, 1> force =
+        Eigen::Matrix<double, 12, 1>::Zero();
+    Eigen::Matrix<double, go2::kJointCount, 1> tau =
+        Eigen::Matrix<double, go2::kJointCount, 1>::Zero();
+};
+
+inline Eigen::Matrix<double, 12, kGo2Nv> StackFootJacobian(
+    const RigidBodyDynamics &dyn)
+{
+    Eigen::Matrix<double, 12, kGo2Nv> J = Eigen::Matrix<double, 12, kGo2Nv>::Zero();
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        J.block<3, kGo2Nv>(static_cast<int>(3 * leg), 0) = dyn.foot_jac_world[leg];
+    return J;
+}
+
+inline bool SolveInverseDynamicsWbc(
+    const IdWbcParams &params,
+    const IdWbcInput &input,
+    IdWbcOutput &output)
+{
+    output = IdWbcOutput{};
+    if (!input.dynamics.valid)
+        return false;
+    const auto &M = input.dynamics.mass_matrix;
+    const auto &h = input.dynamics.bias;
+    const auto J = StackFootJacobian(input.dynamics);
+    if (!M.allFinite() || !h.allFinite() || !J.allFinite())
+        return false;
+
+    constexpr int nqdd = kGo2Nv;
+    constexpr int nf = 12;
+    constexpr int n = nqdd + nf;
+    Eigen::MatrixXd H = Eigen::MatrixXd::Zero(n, n);
+    Eigen::VectorXd g = Eigen::VectorXd::Zero(n);
+
+    Eigen::Matrix<double, 6, 1> a_des;
+    a_des << input.desired_linear_acc_world, input.desired_angular_acc_body;
+    Eigen::Matrix<double, 6, 6> Wb = Eigen::Matrix<double, 6, 6>::Zero();
+    Wb.diagonal() << params.w_base_lin, params.w_base_lin, params.w_base_lin,
+        params.w_base_ang, params.w_base_ang, params.w_base_ang;
+    H.topLeftCorner<6, 6>() += 2.0 * Wb;
+    g.head<6>() += -2.0 * Wb * a_des;
+
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        const auto Jl = input.dynamics.foot_jac_world[leg];
+        const int col_f = nqdd + static_cast<int>(3 * leg);
+        if (input.contact[leg])
+        {
+            H.topLeftCorner(nqdd, nqdd) +=
+                2.0 * params.w_stance_no_slip * Jl.transpose() * Jl;
+        }
+        else
+        {
+            H.topLeftCorner(nqdd, nqdd) +=
+                2.0 * params.w_swing * Jl.transpose() * Jl;
+            g.head(nqdd) +=
+                -2.0 * params.w_swing * Jl.transpose() * input.swing_acc_world[leg];
+        }
+        H(col_f, col_f) += 2.0 * params.w_force;
+        H(col_f + 1, col_f + 1) += 2.0 * params.w_force;
+        H(col_f + 2, col_f + 2) += 2.0 * params.w_force;
+    }
+    H.block(6, 6, 12, 12).diagonal().array() += 2.0 * params.w_posture;
+
+    // tau = Mj qdd + hj - Jj^T f,  w_tau ||tau||^2
+    const auto Mj = M.bottomRows<12>();
+    const auto hj = h.tail<12>();
+    const auto Jj_t = J.rightCols<12>().transpose();  // 12 x 12
+    Eigen::MatrixXd tau_map = Eigen::MatrixXd::Zero(12, n);
+    tau_map.block<12, 18>(0, 0) = Mj;
+    tau_map.block<12, 12>(0, 18) = -Jj_t;
+    H += 2.0 * params.w_tau * tau_map.transpose() * tau_map;
+    g += 2.0 * params.w_tau * tau_map.transpose() * hj;
+    H.diagonal().array() += 1.0e-8;
+
+    Eigen::MatrixXd Aeq(6, n);
+    Aeq.leftCols<nqdd>() = M.topRows<6>();
+    Aeq.rightCols<nf>() = -J.leftCols<6>().transpose();
+    const Eigen::VectorXd beq = -h.head<6>();
+
+    const double mu = params.friction_mu / std::sqrt(2.0);
+    const int mineq = 6 * 4 + 24;
+    Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(mineq, n);
+    Eigen::VectorXd bineq = Eigen::VectorXd::Zero(mineq);
+    int row = 0;
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        const int c = nqdd + static_cast<int>(3 * leg);
+        if (!input.contact[leg])
+        {
+            for (int axis = 0; axis < 3; ++axis)
+            {
+                Aineq(row, c + axis) = 1.0;
+                bineq[row] = 0.05;
+                ++row;
+                Aineq(row, c + axis) = -1.0;
+                bineq[row] = 0.05;
+                ++row;
+            }
+            continue;
+        }
+        Aineq(row, c + 2) = -1.0;
+        bineq[row] = -params.min_normal_n;
+        ++row;
+        Aineq(row, c + 2) = 1.0;
+        bineq[row] = params.max_normal_n;
+        ++row;
+        Aineq(row, c + 0) = 1.0;
+        Aineq(row, c + 2) = -mu;
+        ++row;
+        Aineq(row, c + 0) = -1.0;
+        Aineq(row, c + 2) = -mu;
+        ++row;
+        Aineq(row, c + 1) = 1.0;
+        Aineq(row, c + 2) = -mu;
+        ++row;
+        Aineq(row, c + 1) = -1.0;
+        Aineq(row, c + 2) = -mu;
+        ++row;
+    }
+    for (int i = 0; i < 12; ++i)
+    {
+        Aineq.row(row).head(n) = tau_map.row(i);
+        bineq[row] = params.tau_limit_nm - hj[i];
+        ++row;
+        Aineq.row(row).head(n) = -tau_map.row(i);
+        bineq[row] = params.tau_limit_nm + hj[i];
+        ++row;
+    }
+
+    Eigen::VectorXd x;
+    int iters = 0;
+    DenseQpSettings settings;
+    settings.max_iterations = 120;
+    settings.rho = 8.0;
+    settings.abs_tol = 1e-5;
+    settings.rel_tol = 1e-4;
+    settings.feasibility_tol = 1e-4;
+    const bool qp_ok =
+        SolveDenseQpEq(H, g, Aineq, bineq, Aeq, beq, x, iters, settings);
+    if (x.size() != n || !x.allFinite())
+        return false;
+
+    output.ok = true;
+    output.iterations = iters;
+    output.qdd = x.head<nqdd>();
+    output.force = x.tail<nf>();
+    output.tau = Mj * output.qdd + hj - Jj_t * output.force;
+    output.eq_residual = (Aeq * x - beq).norm();
+    output.rne_residual =
+        (M * output.qdd + h - J.transpose() * output.force).head<6>().norm();
+    if (output.eq_residual >= 5.0)
+        return false;
+    output.ok = qp_ok || output.eq_residual < 1.0e-2;
+    return output.ok;
+}
+
+}  // namespace go2_control

--- a/example/cpp/scripts/go2sim
+++ b/example/cpp/scripts/go2sim
@@ -6,7 +6,7 @@
 #   go2sim                    # default 64-cycle headless walk
 #   go2sim fast               # faster preset
 #   go2sim task               # stand -> walk -> lie sequence
-#   go2sim full               # trot with centroidal W=Ma+h wrench
+#   go2sim full               # trot with 18-DoF ID-WBC + SRBD MPC
 #   go2sim turn 0.3           # turning command
 #   go2sim dist 3.0           # velocity disturbance (m/s)
 #   go2sim payload 10         # payload (kg)
@@ -30,7 +30,7 @@ case "$SCENE" in
   imp)     ARGS=(--period 0.50 --step-length 0.080 --kd 5.0 --tau-limit 35 --impulse --raibert-velocity-gain 0.20 --raibert-max-adjustment 0.040 --max-cycles 64) ;;
   fast)    ARGS=(--step-length 0.110 --tau-limit 19 --max-cycles 64) ;;
   task)    ARGS=(--step-length 0.091 --task stand-walk-lie) ;;
-  full)    ARGS=(--step-length 0.091 --wbc-full --max-cycles 64) ;;
+  full)    ARGS=(--step-length 0.091 --wbc-full --tau-limit 35 --max-cycles 64) ;;
   turn)    ARGS=(--step-length 0.091 --turn-rate "${1:-0.3}" --max-cycles 64); [ $# -gt 0 ] && shift ;;
   dist)    ARGS=(--step-length 0.091 --push-time 4.0 --push-vel-x "${1:-1.5}" --push-duration 0.05 --max-cycles 64); [ $# -gt 0 ] && shift ;;
   payload) ARGS=(--step-length 0.091 --payload-kg "${1:-5}" --max-cycles 64); [ $# -gt 0 ] && shift ;;

--- a/example/cpp/srbd_mpc.h
+++ b/example/cpp/srbd_mpc.h
@@ -1,0 +1,322 @@
+#pragma once
+
+// Receding-horizon single-rigid-body MPC (Di Carlo / Mini Cheetah class).
+// Decision variables are contact forces at each knot. State is condensed.
+// Friction pyramid and swing-foot zeros are hard. First-knot force and
+// implied CoM acceleration are the WBC reference.
+
+#include <array>
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "dense_qp.h"
+#include "go2_forward_kinematics.h"
+
+namespace go2_control
+{
+
+constexpr int kSrbdStateSize = 12;
+constexpr int kSrbdMaxHorizon = 12;
+constexpr int kSrbdForceSize = 12;
+
+struct SrbdMpcParams
+{
+    int horizon = 10;
+    double dt_s = 0.05;
+    double gravity_mps2 = 9.81;
+    double friction_mu = 0.8;
+    double min_normal_n = 2.0;
+    double max_normal_n = 180.0;
+    double mass_kg = 15.206;
+    Eigen::Matrix3d inertia_com_world = Eigen::Matrix3d::Identity();
+    double w_pos_xy = 40.0;
+    double w_pos_z = 80.0;
+    double w_ori = 80.0;
+    double w_vel_xy = 20.0;
+    double w_vel_z = 8.0;
+    double w_omega = 4.0;
+    double w_force = 1.0e-4;
+    double w_force_trot_xy = 4.0e-4;
+};
+
+struct SrbdMpcInput
+{
+    // x = [roll, pitch, yaw, px, py, pz, wx, wy, wz, vx, vy, vz]
+    Eigen::Matrix<double, kSrbdStateSize, 1> state =
+        Eigen::Matrix<double, kSrbdStateSize, 1>::Zero();
+    Eigen::Matrix<double, kSrbdStateSize, 1> reference =
+        Eigen::Matrix<double, kSrbdStateSize, 1>::Zero();
+    std::array<Eigen::Vector3d, go2::kLegCount> foot_from_com_world{};
+    std::array<std::array<bool, go2::kLegCount>, kSrbdMaxHorizon> contact{};
+};
+
+struct SrbdMpcOutput
+{
+    bool ok = false;
+    int iterations = 0;
+    double cost = 0.0;
+    Eigen::Matrix<double, kSrbdForceSize, 1> first_force =
+        Eigen::Matrix<double, kSrbdForceSize, 1>::Zero();
+    Eigen::Vector3d first_linear_acc = Eigen::Vector3d::Zero();
+    Eigen::Vector3d first_angular_acc = Eigen::Vector3d::Zero();
+    Eigen::Matrix<double, kSrbdStateSize, 1> predicted_state =
+        Eigen::Matrix<double, kSrbdStateSize, 1>::Zero();
+};
+
+inline Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize> SrbdAd(
+    double dt_s)
+{
+    Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize> A =
+        Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize>::Identity();
+    A.block<3, 3>(0, 6) = dt_s * Eigen::Matrix3d::Identity();
+    A.block<3, 3>(3, 9) = dt_s * Eigen::Matrix3d::Identity();
+    return A;
+}
+
+inline Eigen::Matrix<double, kSrbdStateSize, kSrbdForceSize> SrbdBd(
+    const SrbdMpcParams &params,
+    const std::array<Eigen::Vector3d, go2::kLegCount> &r_com,
+    const std::array<bool, go2::kLegCount> &contact)
+{
+    Eigen::Matrix<double, kSrbdStateSize, kSrbdForceSize> B =
+        Eigen::Matrix<double, kSrbdStateSize, kSrbdForceSize>::Zero();
+    const Eigen::Matrix3d Iinv = params.inertia_com_world.inverse();
+    const double dt = params.dt_s;
+    const double inv_m = 1.0 / params.mass_kg;
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        if (!contact[leg])
+            continue;
+        const int c = static_cast<int>(3 * leg);
+        Eigen::Matrix3d skew = Eigen::Matrix3d::Zero();
+        skew << 0.0, -r_com[leg].z(), r_com[leg].y(),
+            r_com[leg].z(), 0.0, -r_com[leg].x(),
+            -r_com[leg].y(), r_com[leg].x(), 0.0;
+        B.block<3, 3>(6, c) = dt * Iinv * skew;
+        B.block<3, 3>(9, c) = dt * inv_m * Eigen::Matrix3d::Identity();
+    }
+    return B;
+}
+
+inline Eigen::Matrix<double, kSrbdStateSize, 1> SrbdGravity(
+    const SrbdMpcParams &params)
+{
+    Eigen::Matrix<double, kSrbdStateSize, 1> g =
+        Eigen::Matrix<double, kSrbdStateSize, 1>::Zero();
+    g[11] = -params.gravity_mps2 * params.dt_s;
+    return g;
+}
+
+inline Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize> SrbdQ(
+    const SrbdMpcParams &params)
+{
+    Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize> Q =
+        Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize>::Zero();
+    Q(0, 0) = params.w_ori;
+    Q(1, 1) = params.w_ori;
+    Q(2, 2) = params.w_ori * 0.25;
+    Q(3, 3) = params.w_pos_xy;
+    Q(4, 4) = params.w_pos_xy;
+    Q(5, 5) = params.w_pos_z;
+    Q(6, 6) = params.w_omega;
+    Q(7, 7) = params.w_omega;
+    Q(8, 8) = params.w_omega;
+    Q(9, 9) = params.w_vel_xy;
+    Q(10, 10) = params.w_vel_xy;
+    Q(11, 11) = params.w_vel_z;
+    return Q;
+}
+
+inline bool SolveSrbdMpc(
+    const SrbdMpcParams &params,
+    const SrbdMpcInput &input,
+    SrbdMpcOutput &output)
+{
+    output = SrbdMpcOutput{};
+    const int N = params.horizon;
+    if (N <= 0 || N > kSrbdMaxHorizon)
+        return false;
+    if (!(params.dt_s > 0.0) ||
+        !(params.mass_kg > 1.0) ||
+        !(params.friction_mu >= 0.0) ||
+        !input.state.allFinite() ||
+        !input.reference.allFinite() ||
+        !params.inertia_com_world.allFinite())
+    {
+        return false;
+    }
+    const Eigen::LDLT<Eigen::Matrix3d> inertia_ldlt(params.inertia_com_world);
+    if (inertia_ldlt.info() != Eigen::Success)
+        return false;
+
+    const int nu = kSrbdForceSize * N;
+    const int nx = kSrbdStateSize * N;
+    Eigen::MatrixXd H_xu = Eigen::MatrixXd::Zero(nx, nu);
+    Eigen::VectorXd d = Eigen::VectorXd::Zero(nx);
+    const auto A = SrbdAd(params.dt_s);
+    const auto g = SrbdGravity(params);
+    Eigen::Matrix<double, kSrbdStateSize, 1> x_pred = input.state;
+    for (int k = 0; k < N; ++k)
+    {
+        const auto B = SrbdBd(params, input.foot_from_com_world, input.contact[k]);
+        x_pred = A * x_pred + g;
+        d.segment<kSrbdStateSize>(kSrbdStateSize * k) = x_pred;
+        Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize> Ak =
+            Eigen::Matrix<double, kSrbdStateSize, kSrbdStateSize>::Identity();
+        for (int j = k; j >= 0; --j)
+        {
+            const auto Bj = SrbdBd(
+                params, input.foot_from_com_world, input.contact[j]);
+            H_xu.block(
+                kSrbdStateSize * k, kSrbdForceSize * j,
+                kSrbdStateSize, kSrbdForceSize) = Ak * Bj;
+            if (j > 0)
+                Ak = Ak * A;
+        }
+        x_pred = d.segment<kSrbdStateSize>(kSrbdStateSize * k);
+    }
+
+    const auto Q = SrbdQ(params);
+    Eigen::MatrixXd Qblk = Eigen::MatrixXd::Zero(nx, nx);
+    Eigen::VectorXd xref = Eigen::VectorXd::Zero(nx);
+    for (int k = 0; k < N; ++k)
+    {
+        Qblk.block<kSrbdStateSize, kSrbdStateSize>(
+            kSrbdStateSize * k, kSrbdStateSize * k) = Q;
+        Eigen::Matrix<double, kSrbdStateSize, 1> knot_ref = input.reference;
+        knot_ref[3] = input.reference[3] +
+            static_cast<double>(k + 1) * params.dt_s * input.reference[9];
+        knot_ref[4] = input.reference[4] +
+            static_cast<double>(k + 1) * params.dt_s * input.reference[10];
+        xref.segment<kSrbdStateSize>(kSrbdStateSize * k) = knot_ref;
+    }
+    Eigen::MatrixXd H = H_xu.transpose() * Qblk * H_xu;
+    Eigen::MatrixXd R = Eigen::MatrixXd::Zero(nu, nu);
+    for (int k = 0; k < N; ++k)
+    {
+        for (int i = 0; i < kSrbdForceSize; ++i)
+        {
+            const int idx = k * kSrbdForceSize + i;
+            const bool lateral = (i % 3) != 2;
+            R(idx, idx) = lateral ? params.w_force_trot_xy : params.w_force;
+        }
+    }
+    H += R;
+    H.diagonal().array() += 1.0e-8;
+    const Eigen::VectorXd gvec =
+        H_xu.transpose() * Qblk * (d - xref);
+
+    const int m = 6 * 4 * N;
+    Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(m, nu);
+    Eigen::VectorXd bineq = Eigen::VectorXd::Zero(m);
+    int row = 0;
+    const double mu = params.friction_mu / std::sqrt(2.0);
+    for (int k = 0; k < N; ++k)
+    {
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            const int c = k * kSrbdForceSize + static_cast<int>(3 * leg);
+            if (!input.contact[k][leg])
+            {
+                for (int axis = 0; axis < 3; ++axis)
+                {
+                    Aineq(row, c + axis) = 1.0;
+                    bineq[row] = 1.0e-6;
+                    ++row;
+                    Aineq(row, c + axis) = -1.0;
+                    bineq[row] = 1.0e-6;
+                    ++row;
+                }
+                continue;
+            }
+            Aineq(row, c + 2) = -1.0;
+            bineq[row] = -params.min_normal_n;
+            ++row;
+            Aineq(row, c + 2) = 1.0;
+            bineq[row] = params.max_normal_n;
+            ++row;
+            Aineq(row, c + 0) = 1.0;
+            Aineq(row, c + 2) = -mu;
+            ++row;
+            Aineq(row, c + 0) = -1.0;
+            Aineq(row, c + 2) = -mu;
+            ++row;
+            Aineq(row, c + 1) = 1.0;
+            Aineq(row, c + 2) = -mu;
+            ++row;
+            Aineq(row, c + 1) = -1.0;
+            Aineq(row, c + 2) = -mu;
+            ++row;
+        }
+    }
+
+    Eigen::VectorXd u;
+    int iters = 0;
+    DenseQpSettings settings;
+    settings.max_iterations = 120;
+    settings.rho = 8.0;
+    settings.abs_tol = 1e-5;
+    settings.rel_tol = 1e-4;
+    settings.feasibility_tol = 1e-4;
+    if (!SolveDenseQp(H, gvec, Aineq, bineq, u, iters, settings) ||
+        u.size() != nu)
+    {
+        return false;
+    }
+
+    output.ok = true;
+    output.iterations = iters;
+    output.first_force = u.head<kSrbdForceSize>();
+    const Eigen::VectorXd X = H_xu * u + d;
+    output.predicted_state = X.head<kSrbdStateSize>();
+    output.cost = 0.5 * u.dot(H * u) + gvec.dot(u);
+    Eigen::Vector3d fsum = Eigen::Vector3d::Zero();
+    Eigen::Vector3d tau = Eigen::Vector3d::Zero();
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        if (!input.contact[0][leg])
+            continue;
+        const Eigen::Vector3d f = output.first_force.segment<3>(3 * leg);
+        fsum += f;
+        tau += input.foot_from_com_world[leg].cross(f);
+    }
+    output.first_linear_acc = fsum / params.mass_kg +
+        Eigen::Vector3d(0.0, 0.0, -params.gravity_mps2);
+    output.first_angular_acc = inertia_ldlt.solve(tau);
+    return true;
+}
+
+// Diagonal trot contact at time t: FR+RL vs FL+RR, offset by half period.
+inline void FillTrotContactSchedule(
+    double gait_time_s,
+    double period_s,
+    double duty,
+    int horizon,
+    double dt_s,
+    std::array<std::array<bool, go2::kLegCount>, kSrbdMaxHorizon> &contact)
+{
+    contact = {};
+    if (!(period_s > 0.0))
+        return;
+    for (int k = 0; k < horizon && k < kSrbdMaxHorizon; ++k)
+    {
+        const double t = gait_time_s + static_cast<double>(k) * dt_s;
+        const double cycle = t / period_s;
+        const double a = cycle - std::floor(cycle);
+        const double b = a + 0.5 - std::floor(a + 0.5);
+        const bool pair_a = a < duty;  // FR, RL
+        const bool pair_b = b < duty;  // FL, RR
+        contact[k][static_cast<std::size_t>(go2::Leg::FR)] = pair_a;
+        contact[k][static_cast<std::size_t>(go2::Leg::RL)] = pair_a;
+        contact[k][static_cast<std::size_t>(go2::Leg::FL)] = pair_b;
+        contact[k][static_cast<std::size_t>(go2::Leg::RR)] = pair_b;
+        if (!pair_a && !pair_b)
+        {
+            contact[k][static_cast<std::size_t>(go2::Leg::FR)] = true;
+            contact[k][static_cast<std::size_t>(go2::Leg::RL)] = true;
+        }
+    }
+}
+
+}  // namespace go2_control

--- a/example/cpp/test_dense_qp.cpp
+++ b/example/cpp/test_dense_qp.cpp
@@ -57,11 +57,48 @@ bool CheckTwoSided()
            Near(x[0], 1.0, 1e-5) && Near(x[1], 0.0, 1e-5);
 }
 
+bool CheckEqualityKkt()
+{
+    Eigen::MatrixXd H = Eigen::MatrixXd::Identity(2, 2);
+    Eigen::VectorXd g = Eigen::VectorXd::Zero(2);
+    Eigen::MatrixXd Aineq(0, 2);
+    Eigen::VectorXd bineq(0);
+    Eigen::MatrixXd Aeq(1, 2);
+    Aeq << 1.0, 1.0;
+    Eigen::VectorXd beq(1);
+    beq[0] = 1.0;
+    Eigen::VectorXd x;
+    int iterations = 0;
+    return go2_control::SolveDenseQpEq(
+               H, g, Aineq, bineq, Aeq, beq, x, iterations) &&
+           Near(x[0], 0.5, 1e-6) && Near(x[1], 0.5, 1e-6);
+}
+
+bool CheckEqualityWithBound()
+{
+    Eigen::MatrixXd H = Eigen::MatrixXd::Identity(2, 2);
+    Eigen::VectorXd g = Eigen::VectorXd::Zero(2);
+    Eigen::MatrixXd Aineq(1, 2);
+    Aineq << 1.0, 0.0;
+    Eigen::VectorXd bineq(1);
+    bineq[0] = 0.2;
+    Eigen::MatrixXd Aeq(1, 2);
+    Aeq << 1.0, 1.0;
+    Eigen::VectorXd beq(1);
+    beq[0] = 1.0;
+    Eigen::VectorXd x;
+    int iterations = 0;
+    return go2_control::SolveDenseQpEq(
+               H, g, Aineq, bineq, Aeq, beq, x, iterations) &&
+           Near(x[0], 0.2, 1e-4) && Near(x[1], 0.8, 1e-4);
+}
+
 }  // namespace
 
 int main()
 {
-    if (!CheckUnconstrained() || !CheckBound() || !CheckTwoSided())
+    if (!CheckUnconstrained() || !CheckBound() || !CheckTwoSided() ||
+        !CheckEqualityKkt() || !CheckEqualityWithBound())
     {
         std::cerr << "dense QP checks failed\n";
         return 1;

--- a/example/cpp/test_go2_rigid_body.cpp
+++ b/example/cpp/test_go2_rigid_body.cpp
@@ -1,0 +1,75 @@
+#include <cmath>
+#include <iostream>
+
+#include "go2_rigid_body.h"
+
+#ifndef GO2_MODEL_PATH
+#define GO2_MODEL_PATH "unitree_robots/go2/go2.xml"
+#endif
+
+namespace
+{
+
+bool Check(bool ok, const char *msg)
+{
+    if (!ok)
+        std::cerr << msg << "\n";
+    return ok;
+}
+
+go2_control::RigidBodyState StandState()
+{
+    go2_control::RigidBodyState state;
+    state.position_world = Eigen::Vector3d(0.0, 0.0, 0.42);
+    state.quat_world_from_body = Eigen::Quaterniond::Identity();
+    state.q << 0.00571868, 0.608813, -1.21763,
+        -0.00571868, 0.608813, -1.21763,
+        0.00571868, 0.608813, -1.21763,
+        -0.00571868, 0.608813, -1.21763;
+    return state;
+}
+
+}  // namespace
+
+int main()
+{
+    go2_control::Go2RigidBody model;
+    if (!model.Load(GO2_MODEL_PATH))
+    {
+        std::cerr << "Failed to load " << GO2_MODEL_PATH << "\n";
+        return 1;
+    }
+    go2_control::RigidBodyDynamics dyn;
+    bool passed = model.Evaluate(StandState(), dyn);
+    passed &= Check(dyn.valid, "dynamics invalid");
+    passed &= Check(
+        std::abs(dyn.mass_kg - 15.206) < 0.2, "mass mismatch");
+    passed &= Check(dyn.com_world.z() > 0.2 && dyn.com_world.z() < 0.5,
+                    "com height");
+    passed &= Check(
+        dyn.mass_matrix.llt().info() == Eigen::Success, "M not SPD");
+    // Gravity generalized force on floating z is ~+mg.
+    passed &= Check(
+        std::abs(dyn.bias[2] - dyn.mass_kg * 9.81) < 25.0,
+        "bias_z is not mg");
+    Eigen::Matrix<double, go2_control::kGo2Nv, 1> qacc =
+        Eigen::Matrix<double, go2_control::kGo2Nv, 1>::Zero();
+    qacc[2] = 0.3;
+    qacc[7] = -0.2;
+    const double rne = model.InverseDynamicsResidual(dyn, qacc);
+    passed &= Check(rne < 0.5, "RNEA residual");
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        passed &= Check(dyn.foot_pos_world[leg].z() > -0.01, "foot z");
+
+    if (!passed)
+    {
+        std::cerr << "mass=" << dyn.mass_kg
+                  << " comz=" << dyn.com_world.z()
+                  << " biasz=" << dyn.bias[2]
+                  << " rne=" << rne << "\n";
+        return 1;
+    }
+    std::cout << "go2 rigid body checks passed. mass=" << dyn.mass_kg
+              << " rne=" << rne << "\n";
+    return 0;
+}

--- a/example/cpp/test_inverse_dynamics_wbc.cpp
+++ b/example/cpp/test_inverse_dynamics_wbc.cpp
@@ -1,0 +1,77 @@
+#include <cmath>
+#include <iostream>
+
+#include "go2_rigid_body.h"
+#include "inverse_dynamics_wbc.h"
+#include "srbd_mpc.h"
+
+#ifndef GO2_MODEL_PATH
+#define GO2_MODEL_PATH "unitree_robots/go2/go2.xml"
+#endif
+
+namespace
+{
+
+bool Check(bool ok, const char *msg)
+{
+    if (!ok)
+        std::cerr << msg << "\n";
+    return ok;
+}
+
+}  // namespace
+
+int main()
+{
+    go2_control::Go2RigidBody model;
+    if (!model.Load(GO2_MODEL_PATH))
+        return 1;
+    go2_control::RigidBodyState state;
+    state.position_world = Eigen::Vector3d(0.0, 0.0, 0.42);
+    state.q << 0.00571868, 0.608813, -1.21763,
+        -0.00571868, 0.608813, -1.21763,
+        0.00571868, 0.608813, -1.21763,
+        -0.00571868, 0.608813, -1.21763;
+    go2_control::RigidBodyDynamics dyn;
+    if (!model.Evaluate(state, dyn))
+        return 1;
+
+    go2_control::IdWbcInput input;
+    input.dynamics = dyn;
+    input.desired_linear_acc_world = Eigen::Vector3d::Zero();
+    input.desired_angular_acc_body = Eigen::Vector3d::Zero();
+    input.contact.fill(true);
+
+    go2_control::IdWbcOutput out;
+    bool passed = go2_control::SolveInverseDynamicsWbc({}, input, out);
+    passed &= Check(out.ok, "stand ID-WBC failed");
+    passed &= Check(out.eq_residual < 1.0e-3, "floating-base residual");
+    passed &= Check(out.rne_residual < 1.0e-3, "RNEA residual");
+    double fz = 0.0;
+    for (int i = 0; i < 4; ++i)
+        fz += out.force[3 * i + 2];
+    passed &= Check(
+        std::abs(fz - dyn.mass_kg * 9.81) < 40.0, "ID-WBC gravity");
+    passed &= Check(out.tau.cwiseAbs().maxCoeff() < 35.0, "tau limit");
+
+    input.contact = {true, false, false, true};
+    go2_control::IdWbcOutput two;
+    passed &= Check(
+        go2_control::SolveInverseDynamicsWbc({}, input, two) && two.ok,
+        "2-contact ID-WBC failed");
+    passed &= Check(two.eq_residual < 5.0e-3, "2-contact eq residual");
+    passed &= Check(two.force.segment<3>(3).norm() < 0.2, "FL force");
+    passed &= Check(two.force.segment<3>(6).norm() < 0.2, "RR force");
+
+    if (!passed)
+    {
+        std::cerr << "eq=" << out.eq_residual
+                  << " rne=" << out.rne_residual
+                  << " fz=" << fz
+                  << " two_eq=" << two.eq_residual << "\n";
+        return 1;
+    }
+    std::cout << "inverse dynamics wbc checks passed. eq=" << out.eq_residual
+              << " rne=" << out.rne_residual << "\n";
+    return 0;
+}

--- a/example/cpp/test_srbd_mpc.cpp
+++ b/example/cpp/test_srbd_mpc.cpp
@@ -1,0 +1,86 @@
+#include <cmath>
+#include <iostream>
+
+#include "srbd_mpc.h"
+
+namespace
+{
+
+bool Check(bool ok, const char *msg)
+{
+    if (!ok)
+        std::cerr << msg << "\n";
+    return ok;
+}
+
+}  // namespace
+
+int main()
+{
+    go2_control::SrbdMpcParams params;
+    params.horizon = 8;
+    params.dt_s = 0.05;
+    params.mass_kg = 15.206;
+    params.inertia_com_world = Eigen::Matrix3d::Zero();
+    params.inertia_com_world.diagonal() << 0.07, 0.12, 0.15;
+
+    go2_control::SrbdMpcInput input;
+    input.state[5] = 0.42;
+    input.reference[5] = 0.42;
+    input.reference[9] = 0.0;
+    input.foot_from_com_world[0] = Eigen::Vector3d(0.20, -0.12, -0.28);
+    input.foot_from_com_world[1] = Eigen::Vector3d(0.20, 0.12, -0.28);
+    input.foot_from_com_world[2] = Eigen::Vector3d(-0.20, -0.12, -0.28);
+    input.foot_from_com_world[3] = Eigen::Vector3d(-0.20, 0.12, -0.28);
+    for (int k = 0; k < params.horizon; ++k)
+        input.contact[k].fill(true);
+
+    go2_control::SrbdMpcOutput four;
+    bool passed = go2_control::SolveSrbdMpc(params, input, four);
+    passed &= Check(four.ok, "4-contact MPC failed");
+    double total_z = 0.0;
+    for (int i = 0; i < 4; ++i)
+        total_z += four.first_force[3 * i + 2];
+    passed &= Check(
+        std::abs(total_z - params.mass_kg * params.gravity_mps2) < 25.0,
+        "4-contact did not carry gravity");
+    passed &= Check(
+        std::abs(four.first_linear_acc.z()) < 2.5,
+        "4-contact az not near 0");
+
+    go2_control::FillTrotContactSchedule(
+        0.24, 0.60, 0.75, params.horizon, params.dt_s, input.contact);
+    go2_control::SrbdMpcOutput two;
+    passed &= Check(
+        go2_control::SolveSrbdMpc(params, input, two) && two.ok,
+        "2-contact MPC failed");
+    total_z = 0.0;
+    int stance = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        if (input.contact[0][static_cast<std::size_t>(i)])
+        {
+            ++stance;
+            total_z += two.first_force[3 * i + 2];
+        }
+        else
+        {
+            passed &= Check(
+                two.first_force.segment<3>(3 * i).norm() < 0.05,
+                "swing force not zero");
+        }
+    }
+    passed &= Check(stance == 2, "trot schedule is not 2-contact");
+    passed &= Check(
+        std::abs(total_z - params.mass_kg * params.gravity_mps2) < 40.0,
+        "2-contact did not carry gravity");
+
+    if (!passed)
+    {
+        std::cerr << "4z=" << four.first_force.transpose()
+                  << " 2z=" << two.first_force.transpose() << "\n";
+        return 1;
+    }
+    std::cout << "srbd mpc checks passed.\n";
+    return 0;
+}

--- a/example/cpp/trot_experiment.h
+++ b/example/cpp/trot_experiment.h
@@ -21,6 +21,9 @@
 #include "locomotion_kernel.h"
 #include "trot_types.h"
 #include "velocity_filter.h"
+#include "go2_rigid_body.h"
+#include "srbd_mpc.h"
+#include "inverse_dynamics_wbc.h"
 
 using unitree::robot::ChannelPublisherPtr;
 using unitree::robot::ChannelSubscriberPtr;
@@ -126,6 +129,9 @@ private:
         bool have_state,
         const unitree_go::msg::dds_::SportModeState_ &high_state_snapshot,
         bool have_high_state);
+    void UpdateWbcFull(
+        const unitree_go::msg::dds_::LowState_ &state_snapshot,
+        const unitree_go::msg::dds_::SportModeState_ &high_state_snapshot);
     bool PrepareWbcTorqueFeedforward(
         std::array<double, go2_trot::kMotorCount> &torque_ff);
     void UpdateVelocityEstimate(
@@ -227,6 +233,11 @@ private:
     std::array<double, go2::kLegCount> wbc_stance_blend_{};
     go2_trot::WbcShadowDiagnostics wbc_shadow_diagnostics_{};
     go2_control::JointTorques wbc_shadow_candidate_torques_{};
+    std::unique_ptr<go2_control::Go2RigidBody> rigid_body_;
+    go2_control::SrbdMpcOutput last_srbd_{};
+    go2_control::IdWbcOutput last_id_wbc_{};
+    bool have_last_id_wbc_ = false;
+    int wbc_full_ticks_ = 0;
     bool dynamics_logged_ = false;
     int motion_stage_ = 0;
     double current_phase_ = 0.0;

--- a/example/cpp/trot_experiment_control.cpp
+++ b/example/cpp/trot_experiment_control.cpp
@@ -357,15 +357,16 @@ bool TrotExperiment::ComputeWbcPrimaryActive(double &gait_elapsed_s)
     gait_started_ ? running_time_ - gait_start_time_s_ : 0.0;
     if (params_.wbc_primary &&
     motion_stage_ == 2 && gait_started_ && !stop_requested_ &&
-    gait_elapsed_s >= kWbcPrimaryEnterDelayS &&
+    gait_elapsed_s >= (params_.wbc_full ? 0.0 : kWbcPrimaryEnterDelayS) &&
     wbc_shadow_diagnostics_.solver_ok &&
     wbc_shadow_diagnostics_.mapping_ok)
     {
     wbc_primary_active = true;
     // [impulse] 大步长时 wrench 力矩需求大, 放宽 primary 力矩上限,
     // 避免退回位置控制后 q_error 硬限误杀。
-    const double max_abs_torque_nm =
-        params_.impulse ? 40.0 : kWbcPrimaryMaxAbsTorqueNm;
+            const double max_abs_torque_nm =
+        params_.impulse ? 40.0
+                        : (params_.wbc_full ? 35.0 : kWbcPrimaryMaxAbsTorqueNm);
     for (int i = 0; i < kMotorCount; ++i)
     {
         const double candidate =
@@ -425,10 +426,12 @@ void TrotExperiment::WriteMotorCommands(
     if (wbc_primary_active)
     {
     // 扭矩渐变注入:激活后 0.5s 内从 0 线性升到 1,避免跳变冲击
-    const double primary_ramp = Clamp(
-        (gait_elapsed_s - kWbcPrimaryEnterDelayS) /
-            kWbcPrimaryRampS,
-        0.0, 1.0);
+    const double primary_ramp = params_.wbc_full
+        ? 1.0
+        : Clamp(
+            (gait_elapsed_s - kWbcPrimaryEnterDelayS) /
+                kWbcPrimaryRampS,
+            0.0, 1.0);
     // 混合控制:支撑腿 = WBC 扭矩(力控制)+ 弱位置;摆动腿 = 位置控制。
     // 接触状态经一阶平滑(swing<->stance 渐变),避免命令跳变冲击。
     for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
@@ -463,9 +466,9 @@ void TrotExperiment::WriteMotorCommands(
                 params_.kd * (1.0 - wbc_stance_blend_[leg]);
             // 低接触数(过渡/对角支撑)时减弱 WBC 扭矩,避免力分配
             // 在支撑切换瞬间扰动姿态
-            const double contact_scale =
-                wbc_shadow_diagnostics_.active_contacts < 3
-                    ? 0.5 : 1.0;
+            const double contact_scale = params_.wbc_full
+                ? (wbc_shadow_diagnostics_.active_contacts < 2 ? 0.0 : 1.0)
+                : (wbc_shadow_diagnostics_.active_contacts < 3 ? 0.5 : 1.0);
             low_cmd_.motor_cmd()[i].tau() =
                 primary_ramp * contact_scale *
                 wbc_stance_blend_[leg] *

--- a/example/cpp/trot_experiment_diagnostics.cpp
+++ b/example/cpp/trot_experiment_diagnostics.cpp
@@ -64,7 +64,8 @@ void TrotExperiment::WriteCsvHeader()
          << ",wbc_shadow_feedforward_reduced_task_gate"
          << ",wbc_shadow_feedforward_gate_code"
          << ",wbc_shadow_feedforward_gate_reason"
-         << ",wbc_shadow_feedforward_max_abs_tau";
+         << ",wbc_shadow_feedforward_max_abs_tau"
+         << ",wbc_full_srbd_ok,wbc_full_id_ok,wbc_full_eq_residual";
     for (int i = 0; i < kMotorCount; ++i)
     {
         csv_ << "," << kMotorNames[i] << "_q_target"
@@ -567,7 +568,10 @@ void TrotExperiment::LogSample(
          << "," << go2_control::WbcFeedforwardGateReasonName(
                 static_cast<go2_control::WbcFeedforwardGateCode>(
                     wbc_shadow_diagnostics_.feedforward_gate_code))
-         << "," << wbc_shadow_diagnostics_.feedforward_max_abs_tau;
+         << "," << wbc_shadow_diagnostics_.feedforward_max_abs_tau
+         << "," << (wbc_shadow_diagnostics_.srbd_ok ? 1 : 0)
+         << "," << (wbc_shadow_diagnostics_.id_wbc_ok ? 1 : 0)
+         << "," << wbc_shadow_diagnostics_.id_eq_residual;
 
     // SECTION: log-joint-cmds (cmd vs state per joint)
     for (int i = 0; i < kMotorCount; ++i)

--- a/example/cpp/trot_experiment_lifecycle.cpp
+++ b/example/cpp/trot_experiment_lifecycle.cpp
@@ -144,6 +144,23 @@ bool TrotExperiment::Init()
     WriteCsvHeader();
     InitLowCmd();
 
+    if (params_.wbc_full)
+    {
+#ifdef GO2_MODEL_PATH
+        rigid_body_ = std::make_unique<go2_control::Go2RigidBody>();
+        if (!rigid_body_->Load(GO2_MODEL_PATH))
+        {
+            std::cerr << "Failed to load Go2 MJCF for --wbc-full: "
+                      << GO2_MODEL_PATH << "\n";
+            return false;
+        }
+        std::cout << "WBC-FULL: 18-DoF MJCF model loaded\n";
+#else
+        std::cerr << "--wbc-full requires a controller-side MuJoCo model\n";
+        return false;
+#endif
+    }
+
     std::cout << "Locomotion kernel: " << locomotion_kernel_->Name() << "\n";
 
     lowcmd_publisher_.reset(

--- a/example/cpp/trot_experiment_wbc.cpp
+++ b/example/cpp/trot_experiment_wbc.cpp
@@ -17,12 +17,271 @@
 #include "contact_state_filter.h"
 #include "go2_contact_torque_mapping.h"
 #include "go2_inverse_kinematics.h"
+#include "inverse_dynamics_wbc.h"
 #include "motion_frame_utils.h"
 #include "preview_footstep_horizon.h"
+#include "srbd_mpc.h"
 
 using namespace unitree::common;
 using namespace unitree::robot;
 using namespace go2_trot;
+
+namespace
+{
+
+go2_control::RigidBodyState MakeRigidBodyState(
+    const unitree_go::msg::dds_::LowState_ &low,
+    const unitree_go::msg::dds_::SportModeState_ &high)
+{
+    const WorldPose pose = ComputeWorldPose(low, high);
+    go2_control::RigidBodyState state;
+    state.position_world = Eigen::Vector3d(pose.base.x, pose.base.y, pose.base.z);
+    state.quat_world_from_body = Eigen::Quaterniond(
+        pose.quaternion[0], pose.quaternion[1],
+        pose.quaternion[2], pose.quaternion[3]);
+    state.linear_vel_world = Eigen::Vector3d(
+        high.velocity()[0], high.velocity()[1], high.velocity()[2]);
+    state.angular_vel_body = Eigen::Vector3d(
+        low.imu_state().gyroscope()[0],
+        low.imu_state().gyroscope()[1],
+        low.imu_state().gyroscope()[2]);
+    for (int i = 0; i < kMotorCount; ++i)
+    {
+        state.q[i] = low.motor_state()[i].q();
+        state.dq[i] = low.motor_state()[i].dq();
+    }
+    return state;
+}
+
+}  // namespace
+
+void TrotExperiment::UpdateWbcFull(
+    const unitree_go::msg::dds_::LowState_ &state_snapshot,
+    const unitree_go::msg::dds_::SportModeState_ &high_state_snapshot)
+{
+    wbc_shadow_diagnostics_.enabled = true;
+    if (!rigid_body_ || !rigid_body_->loaded())
+        return;
+    go2_control::RigidBodyDynamics dyn;
+    if (!rigid_body_->Evaluate(
+            MakeRigidBodyState(state_snapshot, high_state_snapshot), dyn))
+    {
+        return;
+    }
+    if (!dynamics_logged_)
+    {
+        dynamics_logged_ = true;
+        std::cout << "WBC-FULL rigid body mass=" << dyn.mass_kg
+                  << " com_z=" << dyn.com_world.z()
+                  << " bias_z=" << dyn.bias[2] << "\n";
+    }
+
+    const double gait_elapsed =
+        gait_started_ ? running_time_ - gait_start_time_s_ : 0.0;
+    std::array<bool, go2::kLegCount> measured_contact{};
+    const go2_control::HystereticContactParams contact_params{
+        kShadowContactOnForceN, kShadowContactOffForceN};
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        const double force = state_snapshot.foot_force()[leg];
+        bool next_contact = false;
+        if (!go2_control::UpdateHystereticContact(
+                wbc_shadow_contact_state_[leg], force, contact_params,
+                next_contact))
+            return;
+        wbc_shadow_contact_state_[leg] = next_contact;
+        measured_contact[leg] = next_contact;
+    }
+    // During trot the force sensors stay high through lift-off, so measured
+    // 3/4-contact at a scheduled diagonal. The QP uses the gait schedule.
+    std::array<bool, go2::kLegCount> qp_contact = measured_contact;
+    if (gait_started_ && motion_stage_ == 2)
+    {
+        std::array<std::array<bool, go2::kLegCount>, go2_control::kSrbdMaxHorizon>
+            scheduled{};
+        go2_control::FillTrotContactSchedule(
+            gait_elapsed, params_.period_s, params_.duty_factor,
+            1, 0.05, scheduled);
+        qp_contact = scheduled[0];
+    }
+    int contact_mask = 0;
+    int active = 0;
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        if (qp_contact[leg])
+        {
+            ++active;
+            contact_mask |= 1 << static_cast<int>(leg);
+        }
+    }
+    wbc_shadow_diagnostics_.active_contacts = active;
+    wbc_shadow_diagnostics_.contact_mask = contact_mask;
+
+    go2_control::SrbdMpcParams mpc_params;
+    mpc_params.horizon = 6;
+    mpc_params.dt_s = 0.05;
+    mpc_params.mass_kg = dyn.mass_kg;
+    mpc_params.inertia_com_world = dyn.inertia_com_world;
+    mpc_params.friction_mu = kShadowWbcFrictionCoefficient;
+    const bool run_mpc =
+        (wbc_full_ticks_ % 25) == 0 || !last_srbd_.ok;
+    if (run_mpc)
+    {
+        go2_control::SrbdMpcInput mpc_in;
+        mpc_in.state[0] = state_snapshot.imu_state().rpy()[0];
+        mpc_in.state[1] = state_snapshot.imu_state().rpy()[1];
+        mpc_in.state[2] = state_snapshot.imu_state().rpy()[2];
+        mpc_in.state[3] = dyn.com_world.x();
+        mpc_in.state[4] = dyn.com_world.y();
+        mpc_in.state[5] = dyn.com_world.z();
+        mpc_in.state[6] = state_snapshot.imu_state().gyroscope()[0];
+        mpc_in.state[7] = state_snapshot.imu_state().gyroscope()[1];
+        mpc_in.state[8] = state_snapshot.imu_state().gyroscope()[2];
+        mpc_in.state[9] = high_state_snapshot.velocity()[0];
+        mpc_in.state[10] = high_state_snapshot.velocity()[1];
+        mpc_in.state[11] = high_state_snapshot.velocity()[2];
+        mpc_in.reference = mpc_in.state;
+        mpc_in.reference[0] = 0.0;
+        mpc_in.reference[1] = 0.0;
+        mpc_in.reference[4] = 0.0;
+        mpc_in.reference[5] = kWbcPrimaryBaseHeightM;
+        mpc_in.reference[6] = 0.0;
+        mpc_in.reference[7] = 0.0;
+        mpc_in.reference[8] = params_.turn_rate_radps;
+        mpc_in.reference[9] =
+            gait_started_ && motion_stage_ == 2
+                ? params_.direction_sign * params_.step_length_m / params_.period_s
+                : 0.0;
+        mpc_in.reference[10] = 0.0;
+        mpc_in.reference[11] = 0.0;
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+            mpc_in.foot_from_com_world[leg] =
+                dyn.foot_pos_world[leg] - dyn.com_world;
+        if (gait_started_ && motion_stage_ == 2)
+        {
+            go2_control::FillTrotContactSchedule(
+                gait_elapsed, params_.period_s, params_.duty_factor,
+                mpc_params.horizon, mpc_params.dt_s, mpc_in.contact);
+        }
+        else
+        {
+            for (int k = 0; k < mpc_params.horizon; ++k)
+                mpc_in.contact[k] = qp_contact;
+        }
+        go2_control::SrbdMpcOutput mpc_out;
+        if (go2_control::SolveSrbdMpc(mpc_params, mpc_in, mpc_out) && mpc_out.ok)
+            last_srbd_ = mpc_out;
+    }
+    ++wbc_full_ticks_;
+    wbc_shadow_diagnostics_.srbd_ok = last_srbd_.ok;
+
+    go2_control::IdWbcInput wbc_in;
+    wbc_in.dynamics = dyn;
+    wbc_in.contact = qp_contact;
+    if (last_srbd_.ok)
+    {
+        wbc_in.desired_linear_acc_world = last_srbd_.first_linear_acc;
+        const Eigen::Quaterniond quat(
+            state_snapshot.imu_state().quaternion()[0],
+            state_snapshot.imu_state().quaternion()[1],
+            state_snapshot.imu_state().quaternion()[2],
+            state_snapshot.imu_state().quaternion()[3]);
+        wbc_in.desired_angular_acc_body =
+            quat.normalized().toRotationMatrix().transpose() *
+            last_srbd_.first_angular_acc;
+    }
+    if (have_commanded_body_feet_)
+    {
+        const WorldPose pose =
+            ComputeWorldPose(state_snapshot, high_state_snapshot);
+        const Eigen::Quaterniond quat(
+            pose.quaternion[0], pose.quaternion[1],
+            pose.quaternion[2], pose.quaternion[3]);
+        const Eigen::Matrix3d R = quat.normalized().toRotationMatrix();
+        Eigen::Matrix<double, go2_control::kGo2Nv, 1> qvel =
+            Eigen::Matrix<double, go2_control::kGo2Nv, 1>::Zero();
+        qvel.head<3>() = Eigen::Vector3d(
+            high_state_snapshot.velocity()[0],
+            high_state_snapshot.velocity()[1],
+            high_state_snapshot.velocity()[2]);
+        qvel.segment<3>(3) = Eigen::Vector3d(
+            state_snapshot.imu_state().gyroscope()[0],
+            state_snapshot.imu_state().gyroscope()[1],
+            state_snapshot.imu_state().gyroscope()[2]);
+        for (int i = 0; i < kMotorCount; ++i)
+        {
+            const int dof = rigid_body_->MotorDof(i);
+            if (dof >= 6 && dof < go2_control::kGo2Nv)
+                qvel[dof] = state_snapshot.motor_state()[i].dq();
+        }
+        for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+        {
+            if (qp_contact[leg])
+                continue;
+            const Eigen::Vector3d p_des =
+                Eigen::Vector3d(pose.base.x, pose.base.y, pose.base.z) +
+                R * Eigen::Vector3d(
+                        commanded_body_feet_[leg].x,
+                        commanded_body_feet_[leg].y,
+                        commanded_body_feet_[leg].z);
+            const Eigen::Vector3d p = dyn.foot_pos_world[leg];
+            const Eigen::Vector3d v = dyn.foot_jac_world[leg] * qvel;
+            wbc_in.swing_acc_world[leg] = 180.0 * (p_des - p) - 16.0 * v;
+        }
+    }
+
+    go2_control::IdWbcOutput wbc_out;
+    const bool solved =
+        go2_control::SolveInverseDynamicsWbc({}, wbc_in, wbc_out) && wbc_out.ok;
+    if (solved)
+    {
+        last_id_wbc_ = wbc_out;
+        have_last_id_wbc_ = true;
+    }
+    else if (have_last_id_wbc_)
+    {
+        wbc_out = last_id_wbc_;
+    }
+    else
+    {
+        return;
+    }
+
+    wbc_shadow_diagnostics_.solver_ok = true;
+    wbc_shadow_diagnostics_.mapping_ok = true;
+    wbc_shadow_diagnostics_.id_wbc_ok = solved;
+    wbc_shadow_diagnostics_.wrench_satisfied = wbc_out.eq_residual < 1.0;
+    wbc_shadow_diagnostics_.constraint_feasible = true;
+    wbc_shadow_diagnostics_.task_satisfied = wbc_out.eq_residual < 1.0;
+    wbc_shadow_diagnostics_.residual_norm = wbc_out.eq_residual;
+    wbc_shadow_diagnostics_.id_eq_residual = wbc_out.eq_residual;
+    wbc_shadow_diagnostics_.task_residual_norm = wbc_out.rne_residual;
+    wbc_shadow_diagnostics_.iterations = wbc_out.iterations;
+    wbc_shadow_diagnostics_.active_contacts = active;
+    wbc_shadow_diagnostics_.contact_mask = contact_mask;
+    wbc_shadow_diagnostics_.max_abs_tau = wbc_out.tau.cwiseAbs().maxCoeff();
+    wbc_shadow_diagnostics_.desired_force_x_n =
+        last_srbd_.ok ? last_srbd_.first_force[0] + last_srbd_.first_force[3] +
+                            last_srbd_.first_force[6] + last_srbd_.first_force[9]
+                      : 0.0;
+    double min_fz = 1.0e9;
+    for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
+    {
+        const Eigen::Vector3d f = wbc_out.force.segment<3>(3 * static_cast<int>(leg));
+        for (int j = 0; j < 3; ++j)
+        {
+            const int motor = static_cast<int>(3 * leg + j);
+            const int dof = rigid_body_->MotorDof(motor);
+            const int joint_row = dof - 6;
+            wbc_shadow_candidate_torques_[leg][j] =
+                (joint_row >= 0 && joint_row < 12) ? wbc_out.tau[joint_row] : 0.0;
+        }
+        if (qp_contact[leg])
+            min_fz = std::min(min_fz, f.z());
+    }
+    wbc_shadow_diagnostics_.min_contact_normal_force_n =
+        std::isfinite(min_fz) ? min_fz : 0.0;
+}
 
 // --- TrotExperiment::UpdateWbcShadow ---
 void TrotExperiment::UpdateWbcShadow(
@@ -32,6 +291,20 @@ void TrotExperiment::UpdateWbcShadow(
     bool have_high_state)
 {
     wbc_shadow_diagnostics_ = WbcShadowDiagnostics{};
+    const auto shadow_start = std::chrono::steady_clock::now();
+    const auto finish_shadow_timing = [&]() {
+        wbc_shadow_diagnostics_.elapsed_us =
+            std::chrono::duration<double, std::micro>(
+                std::chrono::steady_clock::now() - shadow_start).count();
+        wbc_shadow_diagnostics_.within_budget =
+            wbc_shadow_diagnostics_.elapsed_us <= kShadowWbcBudgetUs;
+    };
+    if (params_.wbc_full && have_state && have_high_state)
+    {
+        UpdateWbcFull(state_snapshot, high_state_snapshot);
+        finish_shadow_timing();
+        return;
+    }
     const TrueDynamics true_dyn = ExtractTrueDynamics(state_snapshot);
     if (true_dyn.valid && !dynamics_logged_)
     {
@@ -44,14 +317,6 @@ void TrotExperiment::UpdateWbcShadow(
     }
     wbc_shadow_candidate_torques_ = {};
     wbc_shadow_diagnostics_.enabled = params_.wbc_shadow;
-    const auto shadow_start = std::chrono::steady_clock::now();
-    const auto finish_shadow_timing = [&]() {
-        wbc_shadow_diagnostics_.elapsed_us =
-            std::chrono::duration<double, std::micro>(
-                std::chrono::steady_clock::now() - shadow_start).count();
-        wbc_shadow_diagnostics_.within_budget =
-            wbc_shadow_diagnostics_.elapsed_us <= kShadowWbcBudgetUs;
-    };
     if (!params_.wbc_shadow || !have_state)
     {
         finish_shadow_timing();

--- a/example/cpp/trot_types.h
+++ b/example/cpp/trot_types.h
@@ -250,6 +250,9 @@ struct WbcShadowDiagnostics
     double elapsed_us = 0.0;
     bool within_budget = true;
     double max_abs_tau = 0.0;
+    bool srbd_ok = false;
+    bool id_wbc_ok = false;
+    double id_eq_residual = 0.0;
     int feedforward_gate_code =
         static_cast<int>(go2_control::WbcFeedforwardGateCode::kDisabled);
     bool feedforward_ready = false;


### PR DESCRIPTION
`--wbc-full` now loads the Go2 MJCF in the controller, runs receding-horizon SRBD MPC, and solves a 500 Hz inverse-dynamics WBC (`M qdd + h = S^T τ + J^T f`). `go2sim walk` is unchanged.

Same-gate 64-cycle (`0.091/0.60 = 0.151667` m/s):

- measured **0.149 m/s** (ratio **0.985**), 64/64, return to stand
- ID-WBC and SRBD feasible on **100%** of walking ticks
- floating-base residual median **1.8e-7 N**
- lateral 12 mm; cruise roll/pitch 0.34° / 0.18°

Equality QP uses a KKT ADMM (two-sided inequality encoding of `Cx=d` was failing on diagonal stance). Gait-scheduled contacts replace force-sensor 3/4-contact at lift-off.

Faster than 0.15 m/s is not claimed: a 0.25 m/s probe completed at ratio 0.94; 0.30 m/s under-tracked. Contact timing is still on the Raibert kernel.