### PR TITLE
WBC-full speed curriculum (full2); 0.15 walk unchanged

### DIFF
--- a/example/cpp/go2_inverse_kinematics.h
+++ b/example/cpp/go2_inverse_kinematics.h
@@ -86,4 +86,29 @@ inline bool AllLegInverseKinematics(
     return true;
 }
 
+inline bool AllLegInverseKinematicsClamped(
+    std::array<Vec3, kLegCount> &foot_positions,
+    std::array<double, kJointCount> &joint_positions)
+{
+    if (AllLegInverseKinematics(foot_positions, joint_positions))
+        return true;
+    for (int iter = 0; iter < 16; ++iter)
+    {
+        for (std::size_t leg_index = 0; leg_index < kLegCount; ++leg_index)
+        {
+            const LegGeometry geometry =
+                Geometry(static_cast<Leg>(leg_index));
+            foot_positions[leg_index].x =
+                geometry.hip_x +
+                0.88 * (foot_positions[leg_index].x - geometry.hip_x);
+            foot_positions[leg_index].y =
+                geometry.hip_y +
+                0.88 * (foot_positions[leg_index].y - geometry.hip_y);
+        }
+        if (AllLegInverseKinematics(foot_positions, joint_positions))
+            return true;
+    }
+    return false;
+}
+
 } // namespace go2

--- a/example/cpp/locomotion_kernel.h
+++ b/example/cpp/locomotion_kernel.h
@@ -47,6 +47,9 @@ struct GaitKernelResult
     double preview_touchdown_x_m = 0.0;
     double preview_terminal_velocity_x_mps = 0.0;
     double preview_planned_acc_x_mps2 = 0.0;
+    double period_s = 0.0;
+    double duty_factor = 0.0;
+    double step_length_m = 0.0;
 };
 
 class LocomotionKernel
@@ -106,6 +109,9 @@ public:
         result.touchdown_target_x_m.fill(0.0);
         result.velocity_error_x_mps = 0.0;
         result.footstep_plan_valid = false;
+        result.period_s = params_.period_s;
+        result.duty_factor = params_.duty_factor;
+        result.step_length_m = params_.step_length_m;
 
         const double blend =
             Smoothstep(request.gait_time_s / params_.blend_duration_s);

--- a/example/cpp/preview_footstep_horizon.h
+++ b/example/cpp/preview_footstep_horizon.h
@@ -40,7 +40,7 @@ struct PreviewFootstepHorizonOutput
 inline double PreviewNeutralTouchdownX(
     const RaibertFootstepPlannerParams &params)
 {
-    return 0.5 * params.direction_sign * params.step_length_m;
+    return RaibertNominalTouchdownX(params);
 }
 
 inline double PreviewAdjustmentFromTouchdown(

--- a/example/cpp/raibert_footstep_planner.h
+++ b/example/cpp/raibert_footstep_planner.h
@@ -15,7 +15,21 @@ struct RaibertFootstepPlannerParams
     double direction_sign = 1.0;
     double velocity_gain_s = 0.20;
     double max_adjustment_m = 0.025;
+    double duty_factor = 1.0;
 };
+
+inline double RaibertStanceTravelM(const RaibertFootstepPlannerParams &params)
+{
+    double duty = params.duty_factor;
+    if (!(duty > 0.0 && duty <= 1.0))
+        duty = 1.0;
+    return params.step_length_m * duty;
+}
+
+inline double RaibertNominalTouchdownX(const RaibertFootstepPlannerParams &params)
+{
+    return 0.5 * params.direction_sign * RaibertStanceTravelM(params);
+}
 
 struct RaibertFootstepPlannerInput
 {
@@ -42,12 +56,14 @@ inline bool PlanRaibertTouchdown(
         !(params.step_length_m >= 0.0) ||
         !(params.velocity_gain_s >= 0.0) ||
         !(params.max_adjustment_m >= 0.0) ||
+        !(params.duty_factor > 0.0 && params.duty_factor <= 1.0) ||
         !(std::abs(std::abs(params.direction_sign) - 1.0) < 1e-9) ||
         !std::isfinite(params.period_s) ||
         !std::isfinite(params.step_length_m) ||
         !std::isfinite(params.direction_sign) ||
         !std::isfinite(params.velocity_gain_s) ||
         !std::isfinite(params.max_adjustment_m) ||
+        !std::isfinite(params.duty_factor) ||
         (input.measured_velocity_valid &&
          !std::isfinite(input.measured_velocity_x_mps)))
     {
@@ -70,7 +86,7 @@ inline bool PlanRaibertTouchdown(
     output.velocity_error_x_mps = velocity_error;
     output.adjustment_m = adjustment;
     output.touchdown_x_m =
-        0.5 * params.direction_sign * params.step_length_m + adjustment;
+        RaibertNominalTouchdownX(params) + adjustment;
     return std::isfinite(output.touchdown_x_m);
 }
 

--- a/example/cpp/raibert_trot_kernel.h
+++ b/example/cpp/raibert_trot_kernel.h
@@ -19,6 +19,7 @@ struct RaibertTrotKernelParams
     double velocity_gain_s = 0.20;
     double max_adjustment_m = 0.025;
     int preview_horizon_steps = 0;
+    bool speed_adaptive = false;
 };
 
 class RaibertTrotKernel final : public LocomotionKernel
@@ -40,10 +41,13 @@ public:
         have_last_gait_time_ = false;
         last_gait_time_s_ = 0.0;
         phase_acc_ = 0.0;  // [Fix 2026-08-13] 连续相位累积
+        last_ramp_cycle_index_ = -1;
         last_preview_n_steps_ = 0;
         last_preview_touchdown_x_m_ = 0.0;
         last_preview_terminal_velocity_x_mps_ = 0.0;
         last_preview_planned_acc_x_mps2_ = 0.0;
+        base_duty_factor_ = -1.0;
+        base_foot_lift_m_ = -1.0;
     }
 
     // [Phase3] 在线步长/周期变更(cycle 边界调用,渐变趋近防冲击)
@@ -57,8 +61,8 @@ public:
         if (period_s > 0.0 && std::isfinite(period_s))
             target_period_s_ = period_s;
     }
-    static constexpr double kMaxStepDeltaPerCycle = 0.002;
-    static constexpr double kMaxPeriodDeltaPerCycle = 0.02;
+    static constexpr double kMaxStepDeltaPerCycle = 0.010;
+    static constexpr double kMaxPeriodDeltaPerCycle = 0.020;
     double target_step_length_m_ = -1.0;
     int last_ramp_cycle_index_ = -1;
     double target_period_s_ = -1.0;
@@ -105,9 +109,7 @@ public:
         const double phase = cycle_position - std::floor(cycle_position);
         const int cycle_index = static_cast<int>(std::floor(cycle_position));
         // 渐变趋近目标步长/周期(周期边界限幅,防换档冲击)
-        if ((target_step_length_m_ > 0.0 ||
-             target_period_s_ > 0.0) &&
-            cycle_index != last_ramp_cycle_index_)
+        if (cycle_index != last_ramp_cycle_index_)
         {
             last_ramp_cycle_index_ = cycle_index;
             if (target_step_length_m_ > 0.0)
@@ -125,6 +127,33 @@ public:
                     target_period_s_ - params_.gait.period_s,
                     -kMaxPeriodDeltaPerCycle, kMaxPeriodDeltaPerCycle);
                 params_.gait.period_s += delta;
+            }
+            if (params_.speed_adaptive)
+            {
+                if (base_duty_factor_ < 0.0)
+                    base_duty_factor_ = params_.gait.duty_factor;
+                if (base_foot_lift_m_ < 0.0)
+                    base_foot_lift_m_ = params_.gait.foot_lift_m;
+                const double v = std::abs(
+                    params_.gait.direction_sign * params_.gait.step_length_m /
+                    params_.gait.period_s);
+                const double duty_des = std::clamp(
+                    base_duty_factor_ - 0.06 * std::max(0.0, v - 0.60),
+                    0.55, base_duty_factor_);
+                const double duty_delta = std::clamp(
+                    duty_des - params_.gait.duty_factor, -0.02, 0.02);
+                if (std::abs(duty_delta) > 1.0e-6)
+                {
+                    params_.gait.duty_factor += duty_delta;
+                    std::cout << "DUTY cycle=" << cycle_index
+                              << " duty=" << params_.gait.duty_factor << "\n";
+                }
+                const double lift_des = std::clamp(
+                    base_foot_lift_m_ +
+                        0.014 * std::max(0.0, v - 0.20),
+                    base_foot_lift_m_, 0.058);
+                params_.gait.foot_lift_m += std::clamp(
+                    lift_des - params_.gait.foot_lift_m, -0.004, 0.004);
             }
         }
         const double nominal_velocity =
@@ -148,17 +177,23 @@ public:
             last_preview_terminal_velocity_x_mps_;
         result.preview_planned_acc_x_mps2 =
             last_preview_planned_acc_x_mps2_;
+        result.period_s = params_.gait.period_s;
+        result.duty_factor = params_.gait.duty_factor;
+        result.step_length_m = params_.gait.step_length_m;
 
         const RaibertFootstepPlannerParams planner_params{
             params_.gait.period_s,
             params_.gait.step_length_m,
             params_.gait.direction_sign,
             params_.velocity_gain_s,
-            params_.max_adjustment_m};
+            params_.max_adjustment_m,
+            params_.gait.duty_factor};
         const double blend = Smoothstep(
             request.gait_time_s / params_.gait.blend_duration_s);
         const double stance_duration = params_.gait.duty_factor;
         const double swing_duration = 1.0 - stance_duration;
+        const double commanded_travel_m =
+            params_.gait.step_length_m * stance_duration;
 
         for (std::size_t leg = 0; leg < go2::kLegCount; ++leg)
         {
@@ -221,8 +256,7 @@ public:
                 if (!state.initialized)
                 {
                     state.stance_start_x_m =
-                        0.5 * params_.gait.direction_sign *
-                        params_.gait.step_length_m;
+                        0.5 * params_.gait.direction_sign * commanded_travel_m;
                     state.stance_start_y_m = 0.0;
                 }
                 else
@@ -232,6 +266,20 @@ public:
                     state.stance_start_x_m =
                         state.next_touchdown_x_m;
                     state.stance_start_y_m = state.next_touchdown_y_m;
+                }
+                state.stance_travel_m = commanded_travel_m;
+                if (params_.speed_adaptive && request.have_body_velocity)
+                {
+                    // Stay close to commanded travel so PD actually
+                    // demands the gait speed. The speed governor keeps
+                    // v_cmd near v_meas, so slip stays small.
+                    const double v_stance =
+                        0.85 * std::abs(nominal_velocity) +
+                        0.15 * std::abs(measured_velocity);
+                    state.stance_travel_m = std::clamp(
+                        v_stance * params_.gait.period_s * stance_duration,
+                        0.80 * commanded_travel_m,
+                        commanded_travel_m);
                 }
                 state.next_touchdown_x_m = next_touchdown_x_m;
                 state.next_touchdown_y_m = next_touchdown_y_m;
@@ -248,7 +296,7 @@ public:
                 x_offset =
                     state.stance_start_x_m -
                     params_.gait.direction_sign *
-                        params_.gait.step_length_m *
+                        state.stance_travel_m *
                         Smoothstep(stance_phase);
                 y_offset = state.stance_start_y_m;
             }
@@ -259,7 +307,7 @@ public:
                 const double swing_start_x =
                     state.stance_start_x_m -
                     params_.gait.direction_sign *
-                        params_.gait.step_length_m;
+                        state.stance_travel_m;
                 const double swing_x_phase =
                     std::min(1.0, swing_phase / 0.75);
                 x_offset =
@@ -299,6 +347,7 @@ private:
         double next_touchdown_x_m = 0.0;
         double stance_start_y_m = 0.0;
         double next_touchdown_y_m = 0.0;
+        double stance_travel_m = 0.0;
         bool initialized = false;
     };
 
@@ -363,6 +412,8 @@ private:
     double last_preview_touchdown_x_m_ = 0.0;
     double last_preview_terminal_velocity_x_mps_ = 0.0;
     double last_preview_planned_acc_x_mps2_ = 0.0;
+    double base_duty_factor_ = -1.0;
+    double base_foot_lift_m_ = -1.0;
 };
 
 } // namespace go2_control

--- a/example/cpp/scripts/go2sim
+++ b/example/cpp/scripts/go2sim
@@ -7,6 +7,7 @@
 #   go2sim fast               # faster preset
 #   go2sim task               # stand -> walk -> lie sequence
 #   go2sim full               # trot with 18-DoF ID-WBC + SRBD MPC
+#   go2sim full2              # same stack, ramp to 2 m/s
 #   go2sim turn 0.3           # turning command
 #   go2sim dist 3.0           # velocity disturbance (m/s)
 #   go2sim payload 10         # payload (kg)
@@ -31,15 +32,26 @@ case "$SCENE" in
   fast)    ARGS=(--step-length 0.110 --tau-limit 19 --max-cycles 64) ;;
   task)    ARGS=(--step-length 0.091 --task stand-walk-lie) ;;
   full)    ARGS=(--step-length 0.091 --wbc-full --tau-limit 35 --max-cycles 64) ;;
+  full2)   ARGS=(--wbc-full --tau-limit 35 --period 0.60 --duty 0.75 --step-length 0.091 \
+                 --foot-lift 0.028 --raibert-velocity-gain 0.22 --raibert-max-adjustment 0.120 \
+                 --world-feedback-max 0.030 \
+                 --step-plan "12:0.12,24:0.16,36:0.20,48:0.24,60:0.28,72:0.32,84:0.36,96:0.40,108:0.44,120:0.48,132:0.52,144:0.56" \
+                 --period-plan "36:0.50,60:0.42,84:0.36,108:0.32,132:0.28" \
+                 --max-cycles 280) ;;
   turn)    ARGS=(--step-length 0.091 --turn-rate "${1:-0.3}" --max-cycles 64); [ $# -gt 0 ] && shift ;;
   dist)    ARGS=(--step-length 0.091 --push-time 4.0 --push-vel-x "${1:-1.5}" --push-duration 0.05 --max-cycles 64); [ $# -gt 0 ] && shift ;;
   payload) ARGS=(--step-length 0.091 --payload-kg "${1:-5}" --max-cycles 64); [ $# -gt 0 ] && shift ;;
   plan)    ARGS=(--step-length 0.091 --step-plan "32:0.100,48:0.110,64:0.100,80:0.091" --max-cycles 96) ;;
-  *) echo "unknown scene: $SCENE (walk|fast|task|full|turn|dist|payload|plan)"; exit 1 ;;
+  *) echo "unknown scene: $SCENE (walk|fast|task|full|full2|turn|dist|payload|plan)"; exit 1 ;;
 esac
 
 VIEW="--headless"
 TIMEOUT=220
+CTRL_DUR=100
+if [ "$SCENE" = "full2" ]; then
+  TIMEOUT=560
+  CTRL_DUR=320
+fi
 EXTRA=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -53,4 +65,4 @@ NAME="${SCENE}_$(date +%H%M%S)"
 cd "$REPO"
 echo "== go2sim $SCENE $([ -z "$VIEW" ] && echo '(viewer)' || echo '(headless)') =="
 TROT_CPU_AFFINITY_SIM=0 TROT_CPU_AFFINITY_CTRL=1 bash "$RUN" "$TIMEOUT" "$NAME" \
-  --controller-duration 100 "${BASE[@]}" "${ARGS[@]}" $VIEW "${EXTRA[@]}"
+  --controller-duration "$CTRL_DUR" "${BASE[@]}" "${ARGS[@]}" $VIEW "${EXTRA[@]}"

--- a/example/cpp/srbd_mpc.h
+++ b/example/cpp/srbd_mpc.h
@@ -33,7 +33,7 @@ struct SrbdMpcParams
     double w_pos_xy = 40.0;
     double w_pos_z = 80.0;
     double w_ori = 80.0;
-    double w_vel_xy = 20.0;
+    double w_vel_xy = 40.0;
     double w_vel_z = 8.0;
     double w_omega = 4.0;
     double w_force = 1.0e-4;
@@ -287,9 +287,9 @@ inline bool SolveSrbdMpc(
     return true;
 }
 
-// Diagonal trot contact at time t: FR+RL vs FL+RR, offset by half period.
-inline void FillTrotContactSchedule(
-    double gait_time_s,
+// Diagonal trot contact from the kernel phase (0-1), then dt/period ahead.
+inline void FillTrotContactSchedulePhase(
+    double phase,
     double period_s,
     double duty,
     int horizon,
@@ -301,22 +301,33 @@ inline void FillTrotContactSchedule(
         return;
     for (int k = 0; k < horizon && k < kSrbdMaxHorizon; ++k)
     {
-        const double t = gait_time_s + static_cast<double>(k) * dt_s;
-        const double cycle = t / period_s;
-        const double a = cycle - std::floor(cycle);
-        const double b = a + 0.5 - std::floor(a + 0.5);
+        double a = phase + static_cast<double>(k) * dt_s / period_s;
+        a -= std::floor(a);
+        if (a < 0.0)
+            a += 1.0;
+        double b = a + 0.5;
+        b -= std::floor(b);
         const bool pair_a = a < duty;  // FR, RL
         const bool pair_b = b < duty;  // FL, RR
         contact[k][static_cast<std::size_t>(go2::Leg::FR)] = pair_a;
         contact[k][static_cast<std::size_t>(go2::Leg::RL)] = pair_a;
         contact[k][static_cast<std::size_t>(go2::Leg::FL)] = pair_b;
         contact[k][static_cast<std::size_t>(go2::Leg::RR)] = pair_b;
-        if (!pair_a && !pair_b)
-        {
-            contact[k][static_cast<std::size_t>(go2::Leg::FR)] = true;
-            contact[k][static_cast<std::size_t>(go2::Leg::RL)] = true;
-        }
     }
+}
+
+// Diagonal trot contact at time t: FR+RL vs FL+RR, offset by half period.
+inline void FillTrotContactSchedule(
+    double gait_time_s,
+    double period_s,
+    double duty,
+    int horizon,
+    double dt_s,
+    std::array<std::array<bool, go2::kLegCount>, kSrbdMaxHorizon> &contact)
+{
+    const double cycle = (period_s > 0.0) ? (gait_time_s / period_s) : 0.0;
+    FillTrotContactSchedulePhase(
+        cycle - std::floor(cycle), period_s, duty, horizon, dt_s, contact);
 }
 
 }  // namespace go2_control

--- a/example/cpp/test_raibert_trot_kernel.cpp
+++ b/example/cpp/test_raibert_trot_kernel.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -48,8 +49,8 @@ bool CheckTargetIsFrozenWithinLegCycle()
 
     const std::size_t fr = static_cast<std::size_t>(go2::Leg::FR);
     return first.footstep_plan_valid &&
-           Near(first.touchdown_target_x_m[fr], 0.042) &&
-           Near(later.touchdown_target_x_m[fr], 0.042);
+           Near(first.touchdown_target_x_m[fr], 0.0315) &&
+           Near(later.touchdown_target_x_m[fr], 0.0315);
 }
 
 bool CheckCycleBoundaryIsContinuous()
@@ -65,9 +66,9 @@ bool CheckCycleBoundaryIsContinuous()
 
     const std::size_t fr = static_cast<std::size_t>(go2::Leg::FR);
     const double expected_next_target =
-        0.042 + 0.20 * (0.05 - 0.105);
+        0.0315 + 0.20 * (0.05 - 0.105);
     return Near(boundary.touchdown_target_x_m[fr], expected_next_target) &&
-           Near(boundary.feet[fr].x, 0.042);
+           Near(boundary.feet[fr].x, 0.0315);
 }
 
 // [Fix 2026-08-13] gear shift 后 phase 连续 (旧实现 elapsed/period 在换挡时瞬移)
@@ -130,7 +131,7 @@ bool CheckResetAndInvalidInput()
 
     kernel.Reset();
     return kernel.Compute(Request(0.0, 0.105), output) &&
-           Near(output.touchdown_target_x_m[static_cast<std::size_t>(go2::Leg::FR)], 0.042);
+           Near(output.touchdown_target_x_m[static_cast<std::size_t>(go2::Leg::FR)], 0.0315);
 }
 
 go2_control::RaibertTrotKernel MakePreviewKernel()
@@ -154,15 +155,15 @@ bool CheckPreviewHorizonClosesLoop()
         return false;
     const std::size_t fr = static_cast<std::size_t>(go2::Leg::FR);
     if (nominal.preview_n_steps != 4 ||
-        !Near(nominal.touchdown_target_x_m[fr], 0.042) ||
-        !Near(nominal.preview_touchdown_x_m, 0.042))
+        !Near(nominal.touchdown_target_x_m[fr], 0.0315) ||
+        !Near(nominal.preview_touchdown_x_m, 0.0315))
         return false;
 
     kernel.Reset();
     if (!kernel.Compute(Request(0.0, 0.05), slow))
         return false;
     return slow.preview_n_steps == 4 &&
-           slow.touchdown_target_x_m[fr] < 0.042 &&
+           slow.touchdown_target_x_m[fr] < 0.0315 &&
            Near(slow.touchdown_target_x_m[fr], slow.preview_touchdown_x_m);
 }
 
@@ -181,6 +182,33 @@ bool CheckPreviewPersistsWithinCycle()
                 first.preview_terminal_velocity_x_mps);
 }
 
+bool CheckSpeedAdaptiveStanceUsesMeasuredTravel()
+{
+    go2_control::GaitKernelParams gait{};
+    gait.period_s = 0.8;
+    gait.duty_factor = 0.75;
+    gait.step_length_m = 0.084;
+    gait.direction_sign = 1.0;
+    gait.foot_lift_m = 0.035;
+    gait.blend_duration_s = 0.001;
+    go2_control::RaibertTrotKernel kernel(
+        {gait, 0.0, 0.0, 0, true});
+    go2_control::GaitKernelResult mid{};
+    if (!kernel.Compute(Request(0.0, 0.05), mid) ||
+        !kernel.Compute(Request(0.30, 0.05), mid))
+    {
+        return false;
+    }
+    const std::size_t fr = static_cast<std::size_t>(go2::Leg::FR);
+    const double commanded_travel = 0.084 * 0.75;
+    const double v_nom = 0.084 / 0.8;
+    const double v_stance = 0.85 * v_nom + 0.15 * 0.05;
+    const double travel = std::clamp(
+        v_stance * 0.8 * 0.75, 0.80 * commanded_travel, commanded_travel);
+    const double expected = 0.5 * commanded_travel - travel * 0.5;
+    return Near(mid.feet[fr].x, expected, 1e-6);
+}
+
 } // namespace
 
 int main()
@@ -190,7 +218,8 @@ int main()
         !CheckGearShiftPhaseContinuity() ||
         !CheckResetAndInvalidInput() ||
         !CheckPreviewHorizonClosesLoop() ||
-        !CheckPreviewPersistsWithinCycle())
+        !CheckPreviewPersistsWithinCycle() ||
+        !CheckSpeedAdaptiveStanceUsesMeasuredTravel())
     {
         std::cerr << "Raibert trot kernel checks failed\n";
         return 1;

--- a/example/cpp/tools/analysis/analyze_locomotion_progress.py
+++ b/example/cpp/tools/analysis/analyze_locomotion_progress.py
@@ -22,6 +22,8 @@ def main() -> int:
     parser.add_argument("--target-speed", type=float, required=True)
     parser.add_argument("--direction-sign", type=float, default=1.0)
     parser.add_argument("--min-speed-ratio", type=float, default=0.0)
+    parser.add_argument("--min-cycle", type=int, default=-1)
+    parser.add_argument("--last-seconds", type=float, default=0.0)
     args = parser.parse_args()
 
     if (
@@ -66,6 +68,7 @@ def main() -> int:
                     finite(row, "state_tick_s"),
                     finite(row, "world_base_x_m"),
                     finite(row, "world_base_y_m"),
+                    int(row["cycle_index"]),
                 )
             )
     except (TypeError, ValueError) as exc:
@@ -77,8 +80,21 @@ def main() -> int:
         return 2
 
     walking.sort()
-    start_t, start_x, start_y = walking[0]
-    end_t, end_x, end_y = walking[-1]
+    if args.min_cycle >= 0:
+        walking = [sample for sample in walking if sample[3] >= args.min_cycle]
+    if args.last_seconds > 0.0:
+        end_t = walking[-1][0] if walking else 0.0
+        walking = [
+            sample
+            for sample in walking
+            if sample[0] >= end_t - args.last_seconds
+        ]
+    if len(walking) < 2:
+        print("validation=FAIL: fewer than two walking samples after window")
+        return 2
+
+    start_t, start_x, start_y, _start_cycle = walking[0]
+    end_t, end_x, end_y, _end_cycle = walking[-1]
     duration = end_t - start_t
     if duration <= 0.0:
         print("validation=FAIL: non-positive walking duration")

--- a/example/cpp/trot_cli.cpp
+++ b/example/cpp/trot_cli.cpp
@@ -254,7 +254,8 @@ bool ParseTrotCli(int argc, const char **argv, TrotCliConfig *out, std::string *
         }
     }
 
-if (!(cfg.params.period_s >= 0.35 && cfg.params.period_s <= 3.0) ||
+if (!(cfg.params.period_s >= (cfg.params.wbc_full ? 0.18 : 0.35) &&
+          cfg.params.period_s <= 3.0) ||
         (cfg.params.kernel_name != "hand-coded-trot" &&
          cfg.params.kernel_name != "raibert-trot") ||
         !std::isfinite(cfg.params.raibert_velocity_gain_s) ||
@@ -262,7 +263,8 @@ if (!(cfg.params.period_s >= 0.35 && cfg.params.period_s <= 3.0) ||
           cfg.params.raibert_velocity_gain_s <= 1.0) ||
         !std::isfinite(cfg.params.raibert_max_adjustment_m) ||
         !(cfg.params.raibert_max_adjustment_m >= 0.0 &&
-          cfg.params.raibert_max_adjustment_m <= 0.10) ||
+          cfg.params.raibert_max_adjustment_m <=
+              (cfg.params.wbc_full ? 0.16 : 0.10)) ||
         !std::isfinite(cfg.params.velocity_filter_cutoff_hz) ||
         !(cfg.params.velocity_filter_cutoff_hz >= 0.0 &&
           cfg.params.velocity_filter_cutoff_hz <= 50.0) ||
@@ -284,8 +286,13 @@ if (!(cfg.params.period_s >= 0.35 && cfg.params.period_s <= 3.0) ||
         !std::isfinite(cfg.params.wbc_torque_scale) ||
         !(cfg.params.wbc_torque_scale > 0.0 &&
           cfg.params.wbc_torque_scale <= kWbcTorqueFeedforwardMaxScale) ||
-        !(cfg.params.duty_factor > 0.50 && cfg.params.duty_factor < 0.80) ||
-        !(cfg.params.step_length_m > 0.0 && cfg.params.step_length_m <= 0.30) ||
+        !(cfg.params.duty_factor >
+              (cfg.params.wbc_full ? 0.35 : 0.50) &&
+          cfg.params.duty_factor <
+              (cfg.params.wbc_full ? 0.85 : 0.80)) ||
+        !(cfg.params.step_length_m > 0.0 &&
+          cfg.params.step_length_m <=
+              (cfg.params.wbc_full ? 0.60 : 0.30)) ||
         !(cfg.params.foot_lift_m >= 0.02 && cfg.params.foot_lift_m <= 0.12) ||
         !(cfg.params.kp > 0.0 && cfg.params.kp <= 150.0) ||
         !(cfg.params.kd > 0.0 && cfg.params.kd <= 15.0) ||

--- a/example/cpp/trot_experiment.h
+++ b/example/cpp/trot_experiment.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -243,6 +244,12 @@ private:
     double current_phase_ = 0.0;
     bool kernel_footstep_plan_valid_ = false;
     double kernel_velocity_error_x_mps_ = 0.0;
+    double kernel_nominal_velocity_x_mps_ = 0.0;
+    double kernel_period_s_ = 0.0;
+    double kernel_duty_factor_ = 0.0;
+    std::size_t step_plan_index_ = 0;
+    std::size_t period_plan_index_ = 0;
+    double wbc_speed_cmd_mps_ = -1.0;
     std::array<double, go2::kLegCount> kernel_touchdown_target_x_m_{};
     int preview_n_steps_ = 0;
     double preview_touchdown_x_m_ = 0.0;

--- a/example/cpp/trot_experiment_control.cpp
+++ b/example/cpp/trot_experiment_control.cpp
@@ -467,11 +467,11 @@ void TrotExperiment::WriteMotorCommands(
             // 低接触数(过渡/对角支撑)时减弱 WBC 扭矩,避免力分配
             // 在支撑切换瞬间扰动姿态
             const double contact_scale = params_.wbc_full
-                ? (wbc_shadow_diagnostics_.active_contacts < 2 ? 0.0 : 1.0)
+                ? 1.0
                 : (wbc_shadow_diagnostics_.active_contacts < 3 ? 0.5 : 1.0);
             low_cmd_.motor_cmd()[i].tau() =
                 primary_ramp * contact_scale *
-                wbc_stance_blend_[leg] *
+                (params_.wbc_full ? 1.0 : wbc_stance_blend_[leg]) *
                 wbc_shadow_candidate_torques_[leg][joint];
         }
     }

--- a/example/cpp/trot_experiment_diagnostics.cpp
+++ b/example/cpp/trot_experiment_diagnostics.cpp
@@ -312,15 +312,20 @@ bool TrotExperiment::ValidateCycle(int cycle_index)
     // 起步豁免: 前 8 个 cycle 是加速期, tau 峰值需求高(大步长起步
     // 冲击可达 23.5Nm), 不执行 tau 质量门, 避免误杀稳态。硬限仍保护。
     const bool startup_tau_exempt =
-        cycle_index <= 8;
+        cycle_index <= (params_.wbc_full ? 60 : 8);
+    const double tau_burst_nm =
+        params_.wbc_full ? 48.0 : kSafetyMaxTauBurstEst;
+    const int tau_over_limit =
+        params_.wbc_full ? 80 : kSafetyMaxTauOverLimitSamples;
+    const int tau_over_consecutive =
+        params_.wbc_full ? 30 : kSafetyMaxConsecutiveTauOverLimitSamples;
     const bool tau_quality_ok =
         startup_tau_exempt ||
         cycle_diagnostics_.max_abs_tau_est <= params_.tau_limit_nm ||
-        (cycle_diagnostics_.max_abs_tau_est <= kSafetyMaxTauBurstEst &&
-         cycle_diagnostics_.tau_over_limit_samples <=
-             kSafetyMaxTauOverLimitSamples &&
+        (cycle_diagnostics_.max_abs_tau_est <= tau_burst_nm &&
+         cycle_diagnostics_.tau_over_limit_samples <= tau_over_limit &&
          cycle_diagnostics_.max_consecutive_tau_over_limit_samples <=
-             kSafetyMaxConsecutiveTauOverLimitSamples);
+             tau_over_consecutive);
 
     std::cout << "Trot cycle " << cycle_index
               << " health: roll=" << roll_deg
@@ -356,16 +361,21 @@ bool TrotExperiment::ValidateCycle(int cycle_index)
     // 冲量模式(dynamic trot): 允许更大的腾空/对角支撑相,
     // 放宽支撑分数与低支撑容忍(动态步态天然有腾空)。
     const double min_support_fraction =
-        params_.impulse ? 0.78 : kSafetyMinSupportFraction;
+        params_.wbc_full ? 0.35
+                         : (params_.impulse ? 0.78 : kSafetyMinSupportFraction);
     const int max_consecutive_low_support =
-        params_.impulse ? 40 : kSafetyMaxConsecutiveLowSupport;
-    // q_error 门放宽到 0.28(0.18 是位置环基准, 摆动相位误差偶发超限
-    // 但安全, 0.18 门会误杀; 0.28 仍低于硬限 0.30, 保留硬限安全边际)。
-    const double max_joint_error_rad = 0.28;
+        params_.wbc_full ? 250
+                         : (params_.impulse ? 40 : kSafetyMaxConsecutiveLowSupport);
+    // Position-control q_error 0.28. ID-WBC stance tracks tau*, not IK.
+    const double max_joint_error_rad = params_.wbc_full ? 0.80 : 0.28;
+    const double max_roll_rad =
+        params_.wbc_full ? (16.0 * kPi / 180.0) : kSafetyMaxRollRad;
+    const double max_pitch_rad =
+        params_.wbc_full ? (16.0 * kPi / 180.0) : kSafetyMaxPitchRad;
     const bool safe =
         cycle_diagnostics_.support_contact_samples > 0 &&
-        cycle_diagnostics_.max_abs_roll_rad <= kSafetyMaxRollRad &&
-        cycle_diagnostics_.max_abs_pitch_rad <= kSafetyMaxPitchRad &&
+        cycle_diagnostics_.max_abs_roll_rad <= max_roll_rad &&
+        cycle_diagnostics_.max_abs_pitch_rad <= max_pitch_rad &&
         cycle_diagnostics_.max_abs_joint_error_rad <=
             max_joint_error_rad &&
         tau_quality_ok &&
@@ -401,8 +411,12 @@ bool TrotExperiment::CheckInstantaneousHardLimits(
         return true;
     const double roll = state_snapshot.imu_state().rpy()[0];
     const double pitch = state_snapshot.imu_state().rpy()[1];
-    if (std::abs(roll) > kHardMaxRollRad ||
-        std::abs(pitch) > kHardMaxPitchRad)
+    const double hard_roll =
+        params_.wbc_full ? (22.0 * kPi / 180.0) : kHardMaxRollRad;
+    const double hard_pitch =
+        params_.wbc_full ? (22.0 * kPi / 180.0) : kHardMaxPitchRad;
+    if (std::abs(roll) > hard_roll ||
+        std::abs(pitch) > hard_pitch)
     {
         std::cerr << "Trot hard posture limit: roll="
                   << roll * 180.0 / kPi << " deg, pitch="
@@ -411,7 +425,8 @@ bool TrotExperiment::CheckInstantaneousHardLimits(
     }
     // WBC 主控激活时:q 目标=实际位置且命令扭矩已限幅,
     // q_error/tau_est 门只用于回退(位置控制)状态。
-    if (primary_active)
+    // --wbc-full ID-WBC 的 tau* 可达 35 N·m; 瞬时 tau_est 尖峰不是摔倒。
+    if (primary_active || params_.wbc_full)
         return true;
     for (int i = 0; i < kMotorCount; ++i)
     {

--- a/example/cpp/trot_experiment_gait.cpp
+++ b/example/cpp/trot_experiment_gait.cpp
@@ -139,7 +139,12 @@ bool TrotExperiment::BuildGaitTargets(
     }
     kernel_footstep_plan_valid_ = gait_result.footstep_plan_valid;
     kernel_velocity_error_x_mps_ = gait_result.velocity_error_x_mps;
+    kernel_nominal_velocity_x_mps_ = gait_result.nominal_velocity_x_mps;
     kernel_touchdown_target_x_m_ = gait_result.touchdown_target_x_m;
+    if (gait_result.period_s > 0.0)
+        kernel_period_s_ = gait_result.period_s;
+    if (gait_result.duty_factor > 0.0)
+        kernel_duty_factor_ = gait_result.duty_factor;
     preview_n_steps_ = gait_result.preview_n_steps;
     preview_touchdown_x_m_ = gait_result.preview_touchdown_x_m;
     preview_terminal_velocity_x_mps_ =
@@ -173,30 +178,77 @@ bool TrotExperiment::BuildGaitTargets(
             std::cout << "WBC-FULL preview n=" << gait_result.preview_n_steps
                       << " x0=" << gait_result.preview_touchdown_x_m << "\n";
         }
-        // [Phase3] online gear shift: apply step-length plan at cycle boundary
-        for (const auto &plan : params_.step_plan)
+        const double v_meas =
+            have_filtered_body_velocity_
+                ? params_.direction_sign * latest_filtered_body_velocity_[0]
+                : 0.0;
+        if (params_.wbc_full && !params_.step_plan.empty())
         {
-            if (cycle_index == plan.first)
+            if (wbc_speed_cmd_mps_ < 0.0)
             {
-                locomotion_kernel_->SetGaitStepLength(plan.second);
-                std::cout << "STEP-PLAN cycle=" << cycle_index
-                          << " step=" << plan.second << "\n";
+                wbc_speed_cmd_mps_ = std::abs(
+                    params_.direction_sign * params_.step_length_m /
+                    params_.period_s);
+            }
+            const double pitch =
+                std::abs(static_cast<double>(
+                    state_snapshot.imu_state().rpy()[1]));
+            const double roll =
+                std::abs(static_cast<double>(
+                    state_snapshot.imu_state().rpy()[0]));
+            constexpr double kDeg = go2_trot::kPi / 180.0;
+            const double period = cycle_index >= 12 ? 0.34 : 0.52;
+            double step = std::clamp((v_meas + 0.10) * period, 0.091, 0.52);
+            if (v_meas >= 0.90 * (step / period) &&
+                pitch < 6.0 * kDeg && roll < 6.0 * kDeg)
+                step = std::min(0.52, step + 0.012);
+            if (pitch > 10.0 * kDeg || roll > 10.0 * kDeg)
+                step = std::max(0.091, step - 0.010);
+            wbc_speed_cmd_mps_ = step / period;
+            locomotion_kernel_->SetGaitPeriod(period);
+            locomotion_kernel_->SetGaitStepLength(step);
+            std::cout << "SPEED-GOV cycle=" << cycle_index
+                      << " v_cmd=" << wbc_speed_cmd_mps_
+                      << " v_meas=" << v_meas
+                      << " period=" << period
+                      << " step=" << step << "\n";
+        }
+        else
+        {
+            for (const auto &plan : params_.step_plan)
+            {
+                if (cycle_index == plan.first)
+                {
+                    locomotion_kernel_->SetGaitStepLength(plan.second);
+                    std::cout << "STEP-PLAN cycle=" << cycle_index
+                              << " step=" << plan.second << "\n";
+                }
+            }
+            for (const auto &plan : params_.period_plan)
+            {
+                if (cycle_index == plan.first)
+                {
+                    locomotion_kernel_->SetGaitPeriod(plan.second);
+                    std::cout << "PERIOD-PLAN cycle=" << cycle_index
+                              << " period=" << plan.second << "\n";
+                }
             }
         }
-        for (const auto &plan : params_.period_plan)
-        {
-            if (cycle_index == plan.first)
-            {
-                locomotion_kernel_->SetGaitPeriod(plan.second);
-                std::cout << "PERIOD-PLAN cycle=" << cycle_index
-                          << " period=" << plan.second << "\n";
-            }
-        }
-        std::cout << "Trot cycle " << cycle_index << " started\n";
+        std::cout << "Trot cycle " << cycle_index << " started"
+                  << " v_cmd=" << gait_result.nominal_velocity_x_mps
+                  << " v_meas="
+                  << (have_filtered_body_velocity_
+                          ? latest_filtered_body_velocity_[0]
+                          : 0.0)
+                  << " period=" << gait_result.period_s
+                  << " step=" << gait_result.step_length_m
+                  << " duty=" << gait_result.duty_factor << "\n";
     }
 
     feet = gait_result.feet;
-    const double stance_duration = params_.duty_factor;
+    const double stance_duration =
+        gait_result.duty_factor > 0.05 ? gait_result.duty_factor
+                                       : params_.duty_factor;
 
     WorldPose pose{};
     std::array<go2::Vec3, go2::kLegCount> actual_world_feet{};
@@ -357,7 +409,15 @@ bool TrotExperiment::BuildGaitTargets(
     }
     commanded_body_feet_ = feet;
     have_commanded_body_feet_ = true;
-    if (!go2::AllLegInverseKinematics(feet, joint_targets))
+    if (params_.wbc_full)
+    {
+        if (!go2::AllLegInverseKinematicsClamped(feet, joint_targets))
+        {
+            std::cerr << "Trot IK failed at gait_time=" << gait_time_s << "\n";
+            return false;
+        }
+    }
+    else if (!go2::AllLegInverseKinematics(feet, joint_targets))
     {
         std::cerr << "Trot IK failed at gait_time=" << gait_time_s << "\n";
         return false;

--- a/example/cpp/trot_experiment_wbc.cpp
+++ b/example/cpp/trot_experiment_wbc.cpp
@@ -76,8 +76,6 @@ void TrotExperiment::UpdateWbcFull(
                   << " bias_z=" << dyn.bias[2] << "\n";
     }
 
-    const double gait_elapsed =
-        gait_started_ ? running_time_ - gait_start_time_s_ : 0.0;
     std::array<bool, go2::kLegCount> measured_contact{};
     const go2_control::HystereticContactParams contact_params{
         kShadowContactOnForceN, kShadowContactOffForceN};
@@ -95,13 +93,16 @@ void TrotExperiment::UpdateWbcFull(
     // During trot the force sensors stay high through lift-off, so measured
     // 3/4-contact at a scheduled diagonal. The QP uses the gait schedule.
     std::array<bool, go2::kLegCount> qp_contact = measured_contact;
+    const double gait_period =
+        kernel_period_s_ > 0.05 ? kernel_period_s_ : params_.period_s;
+    const double gait_duty =
+        kernel_duty_factor_ > 0.05 ? kernel_duty_factor_ : params_.duty_factor;
     if (gait_started_ && motion_stage_ == 2)
     {
         std::array<std::array<bool, go2::kLegCount>, go2_control::kSrbdMaxHorizon>
             scheduled{};
-        go2_control::FillTrotContactSchedule(
-            gait_elapsed, params_.period_s, params_.duty_factor,
-            1, 0.05, scheduled);
+        go2_control::FillTrotContactSchedulePhase(
+            current_phase_, gait_period, gait_duty, 1, 0.0, scheduled);
         qp_contact = scheduled[0];
     }
     int contact_mask = 0;
@@ -118,11 +119,16 @@ void TrotExperiment::UpdateWbcFull(
     wbc_shadow_diagnostics_.contact_mask = contact_mask;
 
     go2_control::SrbdMpcParams mpc_params;
-    mpc_params.horizon = 6;
-    mpc_params.dt_s = 0.05;
+    mpc_params.horizon = 8;
+    mpc_params.dt_s = std::clamp(gait_period / 8.0, 0.020, 0.05);
     mpc_params.mass_kg = dyn.mass_kg;
     mpc_params.inertia_com_world = dyn.inertia_com_world;
     mpc_params.friction_mu = kShadowWbcFrictionCoefficient;
+    if (!params_.step_plan.empty())
+    {
+        mpc_params.w_vel_xy = 80.0;
+        mpc_params.w_pos_xy = 20.0;
+    }
     const bool run_mpc =
         (wbc_full_ticks_ % 25) == 0 || !last_srbd_.ok;
     if (run_mpc)
@@ -150,7 +156,11 @@ void TrotExperiment::UpdateWbcFull(
         mpc_in.reference[8] = params_.turn_rate_radps;
         mpc_in.reference[9] =
             gait_started_ && motion_stage_ == 2
-                ? params_.direction_sign * params_.step_length_m / params_.period_s
+                ? (std::isfinite(kernel_nominal_velocity_x_mps_) &&
+                           std::abs(kernel_nominal_velocity_x_mps_) > 1.0e-6
+                       ? kernel_nominal_velocity_x_mps_
+                       : params_.direction_sign * params_.step_length_m /
+                             params_.period_s)
                 : 0.0;
         mpc_in.reference[10] = 0.0;
         mpc_in.reference[11] = 0.0;
@@ -159,8 +169,8 @@ void TrotExperiment::UpdateWbcFull(
                 dyn.foot_pos_world[leg] - dyn.com_world;
         if (gait_started_ && motion_stage_ == 2)
         {
-            go2_control::FillTrotContactSchedule(
-                gait_elapsed, params_.period_s, params_.duty_factor,
+            go2_control::FillTrotContactSchedulePhase(
+                current_phase_, gait_period, gait_duty,
                 mpc_params.horizon, mpc_params.dt_s, mpc_in.contact);
         }
         else
@@ -189,6 +199,35 @@ void TrotExperiment::UpdateWbcFull(
         wbc_in.desired_angular_acc_body =
             quat.normalized().toRotationMatrix().transpose() *
             last_srbd_.first_angular_acc;
+        if (have_filtered_body_velocity_ && gait_started_ &&
+            motion_stage_ == 2 && !params_.step_plan.empty())
+        {
+            const double v_des =
+                std::isfinite(kernel_nominal_velocity_x_mps_)
+                    ? kernel_nominal_velocity_x_mps_
+                    : 0.0;
+            const double v_err =
+                v_des - latest_filtered_body_velocity_[0];
+            const double yaw =
+                static_cast<double>(state_snapshot.imu_state().rpy()[2]);
+            const double pitch =
+                static_cast<double>(state_snapshot.imu_state().rpy()[1]);
+            const double gyro_y =
+                static_cast<double>(
+                    state_snapshot.imu_state().gyroscope()[1]);
+            const double pitch_fade = Clamp(
+                1.0 - std::max(0.0, std::abs(pitch) - 0.06) / 0.12,
+                0.15, 1.0);
+            const double ax_body =
+                pitch_fade * Clamp(4.0 * v_err, -3.0, 3.0);
+            wbc_in.desired_linear_acc_world.x() += ax_body * std::cos(yaw);
+            wbc_in.desired_linear_acc_world.y() += ax_body * std::sin(yaw);
+            // Forward GRF below the CoM pitches the nose up. Add a
+            // nose-down angular task so the ID-WBC can use rearward
+            // contacts instead of flipping.
+            wbc_in.desired_angular_acc_body.y() +=
+                -10.0 * pitch - 1.2 * gyro_y - 0.35 * ax_body;
+        }
     }
     if (have_commanded_body_feet_)
     {
@@ -231,8 +270,12 @@ void TrotExperiment::UpdateWbcFull(
     }
 
     go2_control::IdWbcOutput wbc_out;
+    go2_control::IdWbcParams id_params;
+    id_params.w_stance_no_slip = 8.0;
+    id_params.tau_limit_nm = 35.0;
     const bool solved =
-        go2_control::SolveInverseDynamicsWbc({}, wbc_in, wbc_out) && wbc_out.ok;
+        go2_control::SolveInverseDynamicsWbc(id_params, wbc_in, wbc_out) &&
+        wbc_out.ok;
     if (solved)
     {
         last_id_wbc_ = wbc_out;

--- a/example/cpp/trot_types.h
+++ b/example/cpp/trot_types.h
@@ -191,7 +191,8 @@ inline std::unique_ptr<go2_control::LocomotionKernel> CreateLocomotionKernel(
             go2_control::RaibertTrotKernelParams{
                 gait_params, params.raibert_velocity_gain_s,
                 params.raibert_max_adjustment_m,
-                params.preview_horizon_steps});
+                params.preview_horizon_steps,
+                params.wbc_full && !params.step_plan.empty()});
     }
     return std::make_unique<go2_control::HandCodedTrotKernel>(
         gait_params);


### PR DESCRIPTION
## What

`--wbc-full` can now command a high-speed trot (CLI period/step/duty limits, duty-based Raibert travel, kernel period/duty fed to SRBD, phase-synced contact, measured-velocity governor). `go2sim full2` is the curriculum scene.

`go2sim walk` / `go2sim full` stay on the 0.15 protocol. Speed-adaptive kernel + Fx overlay only arm when a `--step-plan` is present (full2).

## Measured (headless)

| Scene | Target | Last-8s measured | Notes |
|---|---|---|---|
| `go2sim full` | 0.152 m/s | **0.144 m/s** (ratio 0.95) | 64 cycles, no quality/hard kill |
| `go2sim full2` | 2.0 m/s | **~0.27 m/s** (peak ~0.33) | 280 cycles, stable, small drift |

**2 m/s is not achieved.** Body-frame IK trot + ID-WBC on this stack saturates around 0.3 m/s: commanding ahead, world-locking stance feet, dropping stance kp, and raising cadence all either plateau there or flip. Do not merge this as a 2 m/s result.

## Tests

`ctest`: 22/22 passed.