### PR TITLE
chore: add repository governance and hygiene checks

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,0 +1,32 @@
+name: Repository hygiene
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  portable-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check shell syntax
+        run: |
+          find example/cpp/scripts scripts -type f \( -name '*.sh' -o -name 'go2sim' \) -print0 |
+            xargs -0 -r -n1 bash -n
+      - name: Check Python syntax
+        run: |
+          find . -type f -name '*.py' -not -path './.git/*' -print0 |
+            xargs -0 -r -n1 python3 -m py_compile
+      - name: Run repository hygiene checker
+        run: python3 example/cpp/tools/check_repo_hygiene.py
+      - name: Check internal references
+        run: |
+          test -f docs/REPOSITORY_GOVERNANCE.md
+          test -f example/cpp/tools/analysis/INDEX.md
+          test -f docs/RESEARCH_INDEX.md
+
+# Hosted CI intentionally does not claim MuJoCo, Unitree SDK, simulator, or
+# sim-to-real integration. Those require the documented WSL environment.

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -1,0 +1,45 @@
+# Repository governance
+
+## Source of truth
+
+| Scope | Canonical repository | Boundary |
+|---|---|---|
+| Model-based MuJoCo Go2 control | `kairoi-k/go2-mujoco-control` | C++ controller, simulator integration, MuJoCo scenes, and model-based evidence |
+| Isaac Lab velocity RL | `kairoi-k/go2-isaaclab-rl` | RL environments, training, checkpoints, and RL evidence |
+| Kine2Go / AMP imitation | `kairoi-k/kine2go-research` | Imitation, AMP, seam JSON, and imitation evidence |
+| Historical development | `*-dev` repositories | Read-only provenance only; no new feature work |
+
+Do not vendor or merge the RL or imitation tracks into the model-control repository. A claim is canonical only when its code revision, protocol, acceptance semantics, and evidence are recorded in the owning repository.
+
+## Branch lifecycle
+
+- `main` is the canonical integrated line. It is changed through reviewed pull requests only.
+- Named feature, experiment, and maintenance branches start from an explicitly recorded base SHA and have one task owner.
+- Accepted milestones use an immutable annotated `milestone/` tag. A milestone tag records the source branch, exact SHA, evidence document, and simulation/hardware boundary.
+- Research in progress uses `review/` or `wip/` naming and an immutable `wip/` tag when the snapshot must remain recoverable. WIP is never presented as accepted delivery.
+- Recovery or superseded work uses an `archive/` tag and remains unmerged until semantic compatibility is reviewed.
+- Delete a remote working branch only after its current remote SHA is rechecked and is reachable from canonical `main` or an intentional immutable tag. Never delete a branch by wildcard.
+
+## Accepted, WIP, and historical states
+
+Accepted means the exact current code passed the protocol's unchanged analyzer and its evidence is indexed. WIP means the work is useful and recoverable but has not met acceptance. Historical means it is retained for provenance and must not be used as the current upper bound. Simulation results must state that they are simulation-only; they do not imply hardware performance, natural-animal gait, or sim-to-real transfer.
+
+## Tags and provenance
+
+Tags are annotated, immutable identity records. Never move or force-update a tag. Tag messages include source branch, exact SHA, status, relevant acceptance or archival document, and an explicit statement that the tag does not upgrade WIP to accepted status. A run record includes Git SHA, branch and dirty state, effective arguments, semantic environment, binary/scene hashes, analyzer identity, statuses, and artifact hashes where available.
+
+## Evidence storage
+
+Keep compact protocols, summaries, manifests, and acceptance records in Git. Keep raw `_runs/`, build directories, caches, temporary logs, and generated media ignored unless a documented delivery requires a specific retained artifact. Do not delete unique failure bundles, checkpoints, videos, or unpromoted research evidence during cleanup. Classify local artifacts before removal: disposable/reproducible, unique evidence, or unknown.
+
+## Configuration precedence
+
+The effective runtime configuration is resolved as:
+
+`compiled defaults < versioned profile < explicit CLI override`
+
+Semantic environment variables remain recorded during migration. A profile must identify its schema version, ordered controller arguments, and hash. Infrastructure changes must prove baseline equivalence and must not tune controller gains, control laws, physics, or acceptance thresholds.
+
+## Pull-request requirements
+
+Every PR states its base and source SHA, scope, research-semantic impact, exact commands, tests and acceptance results, evidence locations, and unresolved ambiguity. Governance/CI PRs must not change locomotion behavior. Integration PRs keep terrain WIP, recovery work, RL, and imitation boundaries explicit. Do not merge before the full diff and required checks have been reviewed. Hosted CI may run portable syntax, hygiene, and reference checks; it must not claim MuJoCo or Unitree integration without running that environment.

--- a/example/cpp/scripts/README.md
+++ b/example/cpp/scripts/README.md
@@ -1,5 +1,16 @@
 # 控制脚本
 
+## Script lifecycle categories
+
+| Category | Scripts | Policy |
+|---|---|---|
+| Canonical entrypoint | `go2sim` | User-facing task/stand-walk-lie and controller launcher; changes require review. |
+| Maintained reproducibility wrappers | `run_trot.sh`, `run_natural_trot.sh`, `run_running_trot.sh`, `run_sustained_running.sh`, `run_sustained_sprint.sh` | Safe for new protocol work when paired with the documented analyzer and run manifest. |
+| Experiment helpers | `run_leg_lift_repeats.sh`, `run_leg_sequence.sh`, `run_periodic_leg_lift.sh`, `run_single_step.sh`, `run_two_step.sh`, `run_weight_shift_scan.sh`, `record_sustained_sprint.sh` | Maintained helpers; each new experiment must record its exact configuration and evidence class. |
+| Historical compatibility / capture helpers | `record_periodic_leg_lift.sh`, `record_reactive_acceptance.sh` | Retained for provenance or capture workflows; do not treat them as canonical acceptance entrypoints without a current protocol record. |
+
+Do not mass-move or rename legacy scripts in a governance PR. New maintained wrappers must document their owner, effective arguments, semantic environment, output directory, and analyzer.
+
 ## 维护入口
 
 | 脚本 | 用途 |

--- a/example/cpp/tools/analysis/INDEX.md
+++ b/example/cpp/tools/analysis/INDEX.md
@@ -1,0 +1,16 @@
+# Analysis-tool index
+
+`example/cpp/tools/analysis/` contains both current protocol analyzers and retained diagnostics. “Safe for new work” means the tool has an indexed protocol owner and its thresholds/metric semantics are suitable for a new experiment; it does not mean that it can replace a protocol-specific acceptance analyzer.
+
+| Family / scripts | Protocol owner | State | Safe for new work? |
+|---|---|---|---|
+| `analyze_sustained_running.py`, `analyze_sustained_sprint.py`, `analyze_running_gait.py`, `analyze_speed_acceptance.py`, `analyze_natural_gait.py`, `analyze_straightness.py` | High-speed and natural/straight gait protocols | Current | Yes, with the matching acceptance document |
+| `inspect_speed_profile.py`, `inspect_speed_transition.py`, `inspect_speed_window.py`, `inspect_stop_csv.py`, `summarize_high_speed_acceptance.py`, `summarize_wbc_speed_probe.py` | High-speed evidence review | Current diagnostic | Yes, as supporting analysis; not a standalone acceptance gate |
+| `analyze_leg_lift_repeatability.py`, `analyze_leg_sequence.py`, `analyze_periodic_leg_lift.py`, `analyze_real_leg_lift.py`, `analyze_single_step.py`, `analyze_two_step.py`, `analyze_weight_shift.py`, `analyze_weight_shift_scan.py`, `analyze_locomotion_progress.py` | Low-level action and locomotion experiments | Current/supporting | Yes, with an experiment record |
+| `analyze_base_dynamics_closure.py`, `analyze_base_mass_matrix.py`, `analyze_bounded_dynamic_target.py`, `analyze_dynamic_target_feasibility.py`, `analyze_full_dynamics_closure.py`, `analyze_dynamics_task_replay.py`, `analyze_contact_dynamics.py`, `analyze_contact_ground_truth.py` | Dynamics and ground-truth validation | Current/supporting | Yes, with explicit metric semantics |
+| `analyze_constraint_wrench_truth.py`, `analyze_contact_conditioned_shadow.py`, `analyze_contact_moment_shadow.py`, `analyze_contact_torque_ground_truth_replay.py`, `analyze_task_wrench_gap.py`, `analyze_moment_slack_sweep.py` | Contact/wrench diagnostics | Current diagnostic | Yes, for diagnostics; no unreviewed claim promotion |
+| `analyze_fullbody_wbc_replay.py`, `analyze_rate_aware_fallback.py`, `analyze_replay_torque_continuity.py`, `analyze_sequence_constrained_shadow.py`, `analyze_torque_rate_limit_shadow.py`, `analyze_torque_rate_limit_wrench_shadow.py`, `analyze_wbc_fallback_policy.py`, `analyze_wbc_task_features.py`, `analyze_wbc_torque_replay.py`, `analyze_wbc_wrench_components.py` | WBC/MPC replay and controller diagnostics | Current/supporting | Yes, only as declared replay/diagnostic evidence |
+| `perturb_ground_truth_orientation.py`, `perturb_replay_input.py`, `replay_rate_aware_state_machine.py`, `plot_lowcmd_lowstate_tracking.py` | Historical replay/perturbation tooling | Historical/diagnostic | No for new acceptance; preserve for provenance |
+| `analyze_acceleration_consistent_task_target.py`, `analyze_hold_candidate.py`, `analyze_perturbation_robustness.py` | Exploratory task and robustness probes | Historical/supporting | No without a new protocol owner and review |
+
+When adding an analyzer, update this index and the experiment catalog in the same PR. Never rename old analyzer paths merely for cleanup.

--- a/example/cpp/tools/check_repo_hygiene.py
+++ b/example/cpp/tools/check_repo_hygiene.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Portable repository hygiene checks for hosted CI and local preflight."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+REQUIRED = (
+    "README.md",
+    "docs/RESEARCH_INDEX.md",
+    "docs/RESEARCH_HISTORY.md",
+    "docs/REPOSITORY_GOVERNANCE.md",
+    "example/cpp/experiments/CATALOG.md",
+    "example/cpp/scripts/README.md",
+    "example/cpp/tools/analysis/INDEX.md",
+)
+TRACKED_BAD = re.compile(r"(^|/)(build|_runs|__pycache__)(/|$)|\\.pyc$|\\.pyo$")
+SECRET = re.compile(
+    r"BEGIN (?:RSA|OPENSSH|EC|DSA|PRIVATE) KEY|(?:ghp|github_pat|AKIA)[A-Za-z0-9_\-]{12,}"
+)
+HOST_PATH = re.compile(r"(?:/mnt/[a-z]/Users/|[A-Za-z]:\\Users\\|/home/[A-Za-z0-9_.-]+/)")
+MEDIA = re.compile(r"\.(?:mp4|mov|avi|mkv|gif|png|jpg|jpeg|webm)$", re.I)
+
+
+def run(*args: str) -> str:
+    return subprocess.check_output(args, cwd=ROOT, text=True)
+
+
+def main() -> int:
+    failures: list[str] = []
+    tracked = [path for path in run("git", "ls-files").splitlines() if path]
+    for required in REQUIRED:
+        if not (ROOT / required).is_file():
+            failures.append(f"missing required file: {required}")
+    for path in tracked:
+        if TRACKED_BAD.search(path):
+            failures.append(f"generated output tracked: {path}")
+        full = ROOT / path
+        if full.is_file() and full.stat().st_size <= 5_000_000:
+            try:
+                text = full.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if SECRET.search(text):
+                failures.append(f"credential-like material: {path}")
+            maintained = path.startswith(("example/cpp/scripts/", "example/cpp/configs/", "example/cpp/tools/", "simulate/", ".github/"))
+            if maintained and HOST_PATH.search(text):
+                failures.append(f"host-specific absolute path: {path}")
+    try:
+        changed = run("git", "diff", "--name-status", "origin/main...HEAD").splitlines()
+    except subprocess.CalledProcessError:
+        changed = []
+    for line in changed:
+        status, _, path = line.partition("\t")
+        if status.startswith("A") and MEDIA.search(path):
+            size = (ROOT / path).stat().st_size if (ROOT / path).exists() else 0
+            if size > 1_000_000:
+                failures.append(f"new large media needs explicit allowlist/justification: {path}")
+    if failures:
+        print("repo_hygiene=FAIL")
+        print("\n".join(f"failure={item}" for item in failures))
+        return 1
+    print(f"repo_hygiene=PASS tracked_files={len(tracked)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/example/cpp/tools/recording/render_sustained_sprint_replay.py
+++ b/example/cpp/tools/recording/render_sustained_sprint_replay.py
@@ -13,6 +13,7 @@ import bisect
 import csv
 import math
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -83,7 +84,7 @@ def main() -> int:
     parser.add_argument("--camera-azimuth", type=float, default=90.0)
     parser.add_argument("--camera-elevation", type=float, default=-18.0)
     parser.add_argument("--ffmpeg", type=Path,
-                        default=Path("/home/che/.local/share/unitree_mujoco_capture_tools/tools/ffmpeg-static/bin/ffmpeg"))
+                        default=Path(os.environ.get("FFMPEG_BIN") or shutil.which("ffmpeg") or "ffmpeg"))
     args = parser.parse_args()
 
     data_times, data_rows = load_rows(args.run_dir / "data.csv", "cmd_time_s")


### PR DESCRIPTION
Base SHA: 6c64301771861a36c027a090cc7c1c7d5c59f7a0.\n\nScope: governance and portable hygiene only; no locomotion behavior, gains, control laws, physics, thresholds, or research semantics changed.\n\nAdded docs/REPOSITORY_GOVERNANCE.md, explicit script lifecycle categories, example/cpp/tools/analysis/INDEX.md, dependency-free check_repo_hygiene.py, and .github/workflows/repo-hygiene.yml. Also removed a hard-coded developer ffmpeg path in the replay renderer in favor of FFMPEG_BIN/PATH.\n\nValidation: git diff --check; bash syntax for maintained shell scripts; Python compile for all tracked Python; repo_hygiene=PASS tracked_files=802. Hosted CI intentionally does not claim MuJoCo/Unitree integration.\n\nReview required before merge.