### PR TITLE
docs: consolidate current-line guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,3 +30,4 @@ For research-semantic changes, record relevant commit/config/data/evaluator/resu
 - [ ] Scientific claims are bounded by the actual evidence.
 - [ ] No host-specific paths, credentials, or private artifacts were introduced.
 - [ ] Frozen protocols/acceptance criteria were not silently modified.
+- [ ] Phase 2 work follows `CURRENT.md`; no historical/forbidden route was revived.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-09-04
+
+- `main` is the only active integrated line, and `CURRENT.md` is the sole Phase
+  2 route, status, and handoff entrypoint. Superseded remote branches are
+  preserved only by explicit `archive/branches/*` tags.
+- The quasi-static crawl, fixed-leg-order, stop-to-arm, and three-contact-entry
+  terrain actuation chain was removed. Its former public flags fail closed;
+  only sensor-only terrain observation remains usable.
+- Raw `example/cpp/experiments/_runs/` data is ignored, immutable local
+  evidence and can never enter Git. Durable evidence belongs under
+  `docs/research/evidence/` with a manifest.
+- The unrelated `v0.1.0` Isaac Lab release/tag was removed from this model-control
+  repository. Its canonical package remains in `kairoi-k/go2-isaaclab-rl`.
+- Documentation was consolidated around one authority chain and historical
+  leg-lift/multi-step assets were explicitly removed from Phase 2 guidance.
+
 ## 2026-08-19
 
 - `go2sim task` / `full` on main are `--wbc-full --tau-limit 35` (`2b82dae`). Indexed cruise is the 2026-08-18 repeat: `full` n=5 **0.130 ± 0.011 m/s**, `task` n=3 **0.139 ± 0.004 m/s**. Record: `example/cpp/experiments/go2_wbc_full_mainline_repeat_2026-08-18`.
@@ -22,8 +38,10 @@
 ## 2026-08-14
 
 - README clip for stand-walk-lie.
-- Isaac Lab velocity-RL snapshot and `model_54950` were published; that track
-  is now maintained in [`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl).
+- The Isaac Lab velocity-RL snapshot and `model_54950` were part of the former
+  combined-repository history. Their canonical package and release are now in
+  [`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl),
+  not this repository.
 
 ## 2026-08-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,15 @@
 
 Contributions are welcome. Because this repository doubles as a research record, changes that alter experimental meaning need explicit provenance.
 
+Before any Phase 2 work, read [`CURRENT.md`](CURRENT.md) and [`AGENTS.md`](AGENTS.md).
+`CURRENT.md` is the sole route/status authority; architecture, history,
+experiments, issues, commits, and agent handoffs cannot override it.
+
 ## Development
 
 - Keep commits small and scoped.
 - Follow the build/test instructions in `example/cpp/README.md` for the C++ control stack.
-- Do not commit machine-specific absolute paths, credentials, raw bulk logs, or generated build products.
+- Do not commit machine-specific absolute paths, credentials, raw bulk logs, or generated build products. Never modify or commit ignored `example/cpp/experiments/_runs/` evidence.
 - Preserve upstream attribution and licensing when modifying inherited simulator/runtime code.
 
 ## Research-semantic changes

--- a/README.md
+++ b/README.md
@@ -1,206 +1,108 @@
 # Go2 model-based locomotion in MuJoCo
 
-Model-based locomotion research for the Unitree Go2 in MuJoCo: a **500 Hz LowCmd controller** with online velocity commands, gait scheduling, **SRBD MPC**, and **18-DoF inverse-dynamics WBC**.
+A 500 Hz Unitree Go2 `LowCmd` controller with online velocity shaping,
+running-trot scheduling, SRBD MPC, and 18-DoF inverse-dynamics WBC. This is a
+research fork of
+[`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco).
 
-Research fork of [`unitreerobotics/unitree_mujoco`](https://github.com/unitreerobotics/unitree_mujoco).
-
-Current Phase 2 work starts at [`CURRENT.md`](CURRENT.md). It is the sole route,
-status, and handoff authority; historical experiment notes are evidence only.
+**Start current Phase 2 work at [`CURRENT.md`](CURRENT.md).** It is the only
+route, status, and handoff authority; all other notes and artifacts are
+subordinate context or history.
 
 ![stand-walk-lie](docs/media/stand_walk_lie_wbcfull.gif)
 
-## Current results
+## Verified scope
 
-| Capability | Status |
+| Capability | Evidence-backed status |
 |---|---|
-| **3 m/s-class running trot** | Three independent strict revalidations; median speed about **3.23 m/s** |
-| **Runtime arbitrary velocity** | Online 0–3 m/s command path; **15/15** frozen benchmark runs pass quantitative and legacy gates |
-| **Stand → walk → stop → lie** | 500 Hz sequenced `LowCmd` state machine |
-| **Model-based control** | SRBD MPC + 18-DoF ID-WBC with contact, torque, posture, solver, and plan diagnostics |
-| **Terrain-aware locomotion** | Active Phase 2 research; no terrain-crossing claim is made on `main` |
+| Online forward velocity | 0–3 m/s command path; 15/15 frozen benchmark runs passed legacy and quantitative gates |
+| Sustained running-trot | Three exact-head strict revalidations at about 3.23 m/s median |
+| Sequenced control | stand → walk → stop → lie through the 500 Hz state machine |
+| Model-based stack | SRBD MPC + 18-DoF ID-WBC with contact, torque, solver, safety, and plan diagnostics |
+| Terrain | sensor-only Phase 2 interfaces exist; no terrain crossing is accepted on `main` |
 
-All results above are **MuJoCo simulation results**. They do not establish hardware performance, sim-to-real transfer, or natural-animal gait.
+These are MuJoCo simulation results. They do not establish hardware
+performance, sim-to-real transfer, or natural-animal gait. Exact claims and
+boundaries are indexed in [`docs/RESEARCH_INDEX.md`](docs/RESEARCH_INDEX.md).
 
-## Runtime velocity control
-
-The Phase 1 command path is fully online:
-
-```text
-requested velocity profile
-        ↓
-jerk / acceleration-limited shaper
-        ↓
-continuous gait scheduler
-        ↓
-SRBD-MPC velocity reference
-        ↓
-18-DoF ID-WBC
-        ↓
-LowCmd
-```
-
-The frozen benchmark covers:
-
-- stepped commands: `0 → 1 → 2 → 3 → 1 → 0 m/s`;
-- acceleration: `1 → 3 m/s`;
-- braking: `3 → 0 m/s`;
-- continuous ramp: `0 → 3 → 0 m/s`;
-- non-integer commands: `0.6, 1.4, 2.3, 2.8 m/s`.
-
-Each profile was evaluated in three valid runs. All 15 runs passed both the legacy safety/status gate and the frozen quantitative acceptance gate.
-
-See [`PHASE1_RUNTIME_VELOCITY_CLOSEOUT_2026-08-25.md`](docs/validation/PHASE1_RUNTIME_VELOCITY_CLOSEOUT_2026-08-25.md) and [`PHASE1_QUANTITATIVE_ACCEPTANCE_2026-08-25.md`](docs/validation/PHASE1_QUANTITATIVE_ACCEPTANCE_2026-08-25.md).
-
-## Sustained running
-
-A separate immutable running-trot protocol validates sustained 3 m/s-class locomotion.
-
-Three independent strict revalidations passed with median speeds around **3.23 m/s**, bounded attitude, valid running contact structure, clean lifecycle/safety/quality status, and a completed low-speed stop tail.
-
-This benchmark remains separate from the arbitrary-velocity benchmark and retains its own analyzer and thresholds.
-
-See [`SUSTAINED_RUNNING_3MPS_REVALIDATION_2026-08-24.md`](docs/validation/SUSTAINED_RUNNING_3MPS_REVALIDATION_2026-08-24.md).
-
-## Architecture
-
-The controller and MuJoCo simulator run as separate processes and communicate through the Unitree SDK2 / DDS interface.
+## System
 
 ```text
-MuJoCo simulator
-        │
-        │ LowState / SportModeState
-        ▼
-state snapshot + filtering
-        │
-        ▼
-runtime velocity command
-        │
-        ▼
-gait / foothold generation
-        │
-        ▼
-SRBD MPC
-        │
-        ▼
-18-DoF ID-WBC
-        │
-        ▼
-safety gates + saturation
-        │
-        ▼
-LowCmd
-        │
-        └──────────────► MuJoCo
+requested velocity -> Phase 1 shaper -> running-trot gait / footholds
+                                           |
+LowState / lidar -> state snapshot       SRBD MPC
+          |                                |
+          +-> sensor-only terrain        18-DoF ID-WBC
+              model and planner            |
+              (no actuation)       limits / safety / diagnostics
+                                           |
+                                      LowCmd -> MuJoCo
 ```
 
-The main research implementation lives under `example/cpp/`:
+The simulator and controller are separate processes connected through Unitree
+SDK2 DDS. Research code is organized as:
 
 ```text
 example/cpp/
-├── gait/          gait generation, foothold preview and scheduling
-├── contact/       contact filtering and wrench allocation
-├── kinematics/    Go2 FK / IK / Jacobians
+├── trot/          lifecycle, 500 Hz control, gait/WBC integration
+├── gait/          running-trot and foothold generation
+├── terrain/       sensor-derived model and planning interfaces
 ├── wbc/           SRBD MPC, inverse-dynamics WBC, dense QP
-├── trot/          runtime controller and 500 Hz execution path
-├── experiments/   retained experiment records and evidence
-├── tests/         controller and math tests
-└── tools/         analysis and research utilities
+├── contact/       measured contact and wrench handling
+├── kinematics/    Go2 FK, IK, Jacobians, rigid-body model
+├── scripts/       reviewed runners
+├── tests/         unit and integration tests
+├── tools/         protocol analyzers and diagnostics
+└── experiments/   retained evidence records
 ```
 
-For the runtime data flow, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). For source-level navigation, see [`docs/CODE_GUIDE.md`](docs/CODE_GUIDE.md).
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for data flow and
+[`docs/CODE_GUIDE.md`](docs/CODE_GUIDE.md) for source navigation.
 
-## Quick start
+## Build and test
 
-Requires MuJoCo, Unitree SDK2, and the upstream simulator dependencies. `scripts/setup_ubuntu_env.sh` installs system packages; inspect it before running.
+Requires Linux/WSL2, MuJoCo, Unitree SDK2, and the upstream simulator
+dependencies. Review `scripts/setup_ubuntu_env.sh` before using the bootstrap.
 
 ```bash
 cmake -S simulate -B simulate/build
-cmake --build simulate/build -j"$(nproc)"
+cmake --build simulate/build -j2
+ctest --test-dir simulate/build --output-on-failure
 
 cmake -S example/cpp -B example/cpp/build
-cmake --build example/cpp/build -j"$(nproc)"
-
-ctest --test-dir example/cpp/build
+cmake --build example/cpp/build -j2
+ctest --test-dir example/cpp/build --output-on-failure
 ```
 
-Start the MuJoCo simulator, then use the C++ runners documented in [`example/cpp/README.md`](example/cpp/README.md).
+Builds and tests do not establish locomotion acceptance. Phase 2 runs must use
+the exact entrypoints, manifest, experiment lock, and analyzer specified by
+`CURRENT.md`. General and historical runners are classified in
+[`example/cpp/scripts/README.md`](example/cpp/scripts/README.md).
 
-Validated sustained-running entry:
+## Evidence and navigation
 
-```bash
-bash example/cpp/scripts/run_sustained_running.sh --headless
-```
-
-Phase 1 arbitrary-velocity benchmark and analyzer:
-
-```text
-example/cpp/scripts/run_phase1_velocity_benchmark.sh
-example/cpp/scripts/analyze_phase1_velocity.py
-```
-
-## Research and validation
-
-The repository keeps implementation claims separate from exploratory results.
-
-- [`docs/RESEARCH_INDEX.md`](docs/RESEARCH_INDEX.md) — current supported claims;
-- [`docs/RESEARCH_HISTORY.md`](docs/RESEARCH_HISTORY.md) — research milestones, including rejected results;
-- [`docs/validation/`](docs/validation/) — frozen acceptance and revalidation records;
-- [`example/cpp/experiments/CATALOG.md`](example/cpp/experiments/CATALOG.md) — retained experiment artifacts;
-- [`docs/REPRODUCIBILITY.md`](docs/REPRODUCIBILITY.md) — build and reproduction notes.
-
-Bulk generated runs are not committed by default. Reviewable analyzers, manifests, selected evidence, and bounded claims remain in the repository.
-
-## Active research
-
-Phase 2 extends the model-based stack toward sensor-derived terrain representation, foothold/contact planning, and terrain-aware execution.
-
-It remains active research. `main` does **not** currently claim completed or repeatable obstacle-crossing capability.
-
-## Companion tracks
-
-Learning-based work is kept separate from this controller:
-
-| Track | Repository |
+| Need | Start here |
 |---|---|
-| Isaac Lab / RSL-RL velocity locomotion | [`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl) |
-| Kine2Go motion imitation / AMP | [`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research) |
+| Current route/status/next slice | [`CURRENT.md`](CURRENT.md) |
+| Complete documentation map | [`docs/README.md`](docs/README.md) |
+| Reproduction rules | [`docs/REPRODUCIBILITY.md`](docs/REPRODUCIBILITY.md) |
+| Accepted claims | [`docs/RESEARCH_INDEX.md`](docs/RESEARCH_INDEX.md) |
+| Milestones and rejected work | [`docs/RESEARCH_HISTORY.md`](docs/RESEARCH_HISTORY.md) |
+| Retained artifacts | [`example/cpp/experiments/CATALOG.md`](example/cpp/experiments/CATALOG.md) |
+| Upstream boundary | [`UPSTREAM_AND_CONTRIBUTIONS.md`](UPSTREAM_AND_CONTRIBUTIONS.md) |
 
-These repositories are independent research tracks and are not runtime dependencies of the C++ model-based controller.
+Raw `example/cpp/experiments/_runs/` output is ignored immutable local
+evidence: it is never committed or used as instruction. Durable evidence is
+curated under `docs/research/evidence/` with a manifest.
 
-## Repository map
+## Repository boundaries
 
-```text
-example/cpp/       research controller, tests, runners, experiments
-simulate/          Unitree MuJoCo simulator base
-unitree_robots/    Go2 MJCF assets
-docs/              architecture, research records, validation
-docs/media/        README media
-patches/           simulator/runtime patches
-scripts/           environment helpers
-```
+Isaac Lab/RSL-RL velocity locomotion lives in
+[`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl).
+Kine2Go imitation/AMP lives in
+[`kairoi-k/kine2go-research`](https://github.com/kairoi-k/kine2go-research).
+Neither is a runtime dependency or release track of this repository.
 
-Upstream boundaries and project-specific changes are documented in [`UPSTREAM_AND_CONTRIBUTIONS.md`](UPSTREAM_AND_CONTRIBUTIONS.md).
-
-## Scope
-
-Supported claims in this repository are deliberately narrow:
-
-- model-based Go2 control in MuJoCo;
-- 500 Hz stand / locomotion / stop / lie sequencing;
-- SRBD MPC + 18-DoF ID-WBC;
-- validated 3 m/s-class running-trot simulation;
-- quantitatively validated online arbitrary forward-velocity commands.
-
-Not claimed:
-
-- hardware validation;
-- sim-to-real transfer;
-- natural-animal gait;
-- completed terrain traversal;
-- results from the separate RL or imitation repositories.
-
-## License
-
-BSD 3-Clause from the Unitree simulator base.
-
-Third-party assets retain their original terms. See [`NOTICE.md`](NOTICE.md) and [`UPSTREAM_AND_CONTRIBUTIONS.md`](UPSTREAM_AND_CONTRIBUTIONS.md). Citation metadata: [`CITATION.cff`](CITATION.cff).
+BSD 3-Clause from the Unitree simulator base. Third-party assets retain their
+original terms; see [`NOTICE.md`](NOTICE.md). Citation metadata:
+[`CITATION.cff`](CITATION.cff).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,63 +1,67 @@
 # Architecture
 
-The model-based control path uses the same Unitree SDK2 / DDS message interface as the simulator: the controller publishes `LowCmd`, receives `LowState`, and the MuJoCo process bridges those messages to simulated robot dynamics.
+This document maps the code; it does not define research status or the next
+task. For Phase 2, read [`CURRENT.md`](../CURRENT.md) first.
 
 ## Runtime data flow
 
+The MuJoCo process and 500 Hz C++ controller communicate through the Unitree
+SDK2 DDS interface.
+
 ```text
-MuJoCo simulator
-  simulate/build/unitree_mujoco
-          │
-          │ DDS: LowState / LowCmd
-          ▼
-C++ locomotion controller
-  example/cpp/build/real_trot_go2
-          │
-          ├─ state snapshot and filtering
-          ├─ gait phase / Raibert / preview footholds
-          ├─ foot targets → IK → joint targets
-          ├─ world/support feedback
-          ├─ optional contact-force / WBC feedforward
-          ├─ runtime safety gates and saturation
-          └─ diagnostics / CSV logging
+MuJoCo -> LowState / lidar -> state snapshot and filtering
+                                  |
+requested velocity -> Phase 1 shaper -> running-trot gait and footholds
+                                           |
+                                        SRBD MPC
+                                           |
+                                      18-DoF ID-WBC
+                                           |
+                               limits, safety, diagnostics
+                                           |
+                                      LowCmd -> MuJoCo
 ```
 
-The core control loop runs at 500 Hz. The simulator and controller remain separate processes and communicate through the Unitree runtime interface rather than a repository-specific in-process simulation API.
+The sensor-only terrain path derives a terrain model, feasibility results, and
+a plan from lidar. On the current line it may be logged and analyzed, but it
+does not alter gait, MPC, WBC, contact policy, or velocity. There is no
+production terrain-actuation path.
 
-## Main C++ modules
+## Active modules
 
-| Area | Files | Responsibility |
+| Area | Primary files | Responsibility |
 |---|---|---|
-| CLI / lifecycle | `trot_cli.*`, `trot_experiment_lifecycle.cpp` | configuration, DDS setup, startup/shutdown |
-| Control loop | `trot_experiment_control.cpp` | phase sequencing and motor-command publication |
-| Gait generation | `trot_experiment_gait.cpp`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`, `footstep_mpc.h` | diagonal-trot, Raibert, receding-horizon foothold MPC |
-| Kinematics | `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h` | foot/joint transforms and Jacobians |
-| Contact / force allocation | `contact_*`, `contact_wrench_qp.h`, `dense_qp.h`, `go2_contact_torque_mapping.h` | contact-state filtering, wrench QP, torque mapping |
-| Dynamics-informed feedforward | `trot_true_dynamics.h`, `dynamic_acceleration_target.h`, `wbc_runtime_gate.h`, `centroidal_wbc.h`, `go2_rigid_body.h`, `srbd_mpc.h`, `inverse_dynamics_wbc.h` | `--wbc-primary` incremental feedforward; `--wbc-full` 18-DoF ID-WBC + SRBD MPC |
-| Diagnostics | `trot_experiment_diagnostics.cpp`, `trot_types.h` | safety checks, metrics, structured logging |
-| Quasi-static sequence | `leg_lift_*`, `real_leg_lift_go2.cpp` | leg-lift and multi-step experiments |
+| CLI and lifecycle | `example/cpp/trot/trot_cli.*`, `trot_experiment_lifecycle.cpp` | configuration, DDS, startup, shutdown |
+| Control loop | `example/cpp/trot/trot_experiment_control.cpp` | state snapshot, phase execution, command publication |
+| Gait | `example/cpp/trot/trot_experiment_gait.cpp`, `example/cpp/gait/*` | running-trot phase, footholds, velocity targets |
+| Terrain interfaces | `example/cpp/terrain/*` | sensor-derived model, feasibility, immutable plan interface |
+| MPC and WBC | `example/cpp/trot/trot_experiment_wbc.cpp`, `example/cpp/wbc/*` | SRBD preview and inverse-dynamics control |
+| Kinematics | `example/cpp/kinematics/*` | FK, IK, Jacobians, rigid-body model |
+| Contact | `example/cpp/contact/*` | measured-contact filtering, wrench allocation, torque mapping |
+| Timing | `example/cpp/trot/lockstep_*` | lockstep clock/writer diagnostics; not a realtime acceptance claim |
+| Diagnostics | `example/cpp/trot/trot_experiment_diagnostics.cpp`, `trot_types.h` | limits, status, structured logs |
+| Tests and analysis | `example/cpp/tests/`, `example/cpp/tools/` | unit/integration checks and protocol analyzers |
 
-## Model-based control path
+## Phase 2 invariants
 
-At a high level, each control update:
+The Phase 1 shaper remains the only velocity authority. Planned contact and
+force-supported measured contact remain separate. A future terrain execution
+path must publish one immutable, time-indexed snapshot shared by gait, SRBD-MPC,
+and ID-WBC; no consumer may invent its own timing, contact, or recovery state.
 
-1. snapshots joint, IMU, base, and contact observations;
-2. advances the action/gait phase;
-3. computes desired foot positions from the gait kernel and world-frame corrections;
-4. maps foot targets to joint targets with inverse kinematics;
-5. optionally computes contact-force/dynamics-informed feedforward terms;
-6. applies runtime gates, limits, and fallback behavior;
-7. publishes `LowCmd` and records diagnostics.
+The retained `example/cpp/leg_lift/` executable and multi-step configurations
+are historical experiments. They are not a Phase 2 route or design source.
+Removed crawl/three-contact code and Git history are not fallback
+implementations.
 
-The repository describes `--wbc-full` as a controller-side 18-DoF inverse-dynamics WBC plus receding-horizon SRBD MPC. `--wbc-primary` remains incremental dynamics-informed feedforward.
+## Repository boundaries
 
-## Process and asset boundaries
+`simulate/` and `unitree_robots/go2/` remain close to the upstream Unitree
+simulator. Research-specific model control lives in `example/cpp/`. Isaac Lab
+RL and Kine2Go imitation live only in their companion repositories and are not
+runtime dependencies here.
 
-- `simulate/` and `unitree_robots/go2/` originate from the Unitree simulator stack and are kept close to upstream. Other Unitree robot MJCFs are not vendored here.
-- `example/cpp/` contains the main research-specific control work.
-- Isaac Lab / RSL-RL velocity RL is maintained in the separate
-  [`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl)
-  repository and is not coupled to this controller at runtime.
-- the Kine2Go / Genesis motion-imitation work is maintained in a separate companion repository.
-
-For source-level navigation, see [`CODE_GUIDE.md`](CODE_GUIDE.md). For upstream provenance, see [`../UPSTREAM_AND_CONTRIBUTIONS.md`](../UPSTREAM_AND_CONTRIBUTIONS.md).
+See [`CODE_GUIDE.md`](CODE_GUIDE.md) for source navigation,
+[`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) for execution rules, and
+[`../UPSTREAM_AND_CONTRIBUTIONS.md`](../UPSTREAM_AND_CONTRIBUTIONS.md) for
+provenance.

--- a/docs/CODE_GUIDE.md
+++ b/docs/CODE_GUIDE.md
@@ -1,11 +1,14 @@
 # Code guide
 
 This guide points contributors to the smallest relevant source area for common changes. The primary research implementation is under `example/cpp/`.
+For current Phase 2 work, read [`../CURRENT.md`](../CURRENT.md) first; this file
+only maps code and cannot define the route.
 
 ## Entry points
 
 | Task | Start here |
 |---|---|
+| Read current Phase 2 route/status | `CURRENT.md`, then `AGENTS.md` and `docs/research/PHASE2_ACCEPTANCE.md` |
 | Understand the runtime/control data flow | `docs/ARCHITECTURE.md` |
 | Build or run the C++ stack | `example/cpp/README.md` |
 | Change command-line configuration | `example/cpp/trot/trot_cli.*` |
@@ -17,7 +20,10 @@ This guide points contributors to the smallest relevant source area for common c
 | Change `--wbc-full` ID-WBC / SRBD MPC | `example/cpp/kinematics/go2_rigid_body.h`, `example/cpp/wbc/srbd_mpc.h`, `example/cpp/wbc/inverse_dynamics_wbc.h`, `example/cpp/wbc/dense_qp.h`, `example/cpp/trot/trot_experiment_wbc.cpp` |
 | Change dynamics-informed feedforward | `example/cpp/trot/trot_experiment_wbc.cpp`, `example/cpp/trot/trot_true_dynamics.h` |
 | Change safety gates / diagnostics | `example/cpp/trot/trot_experiment_diagnostics.cpp` |
-| Change leg-lift / multi-step experiments | `example/cpp/leg_lift/*`, `example/cpp/leg_lift/real_leg_lift_go2.cpp` |
+| Change sensor-only terrain interfaces | `example/cpp/terrain/*`, `example/cpp/trot/trot_experiment_gait.cpp` |
+| Change timing/lockstep diagnostics | `example/cpp/trot/lockstep_*`, `example/cpp/tests/test_lockstep_*` |
+| Run Phase 2 B0 development checks | `example/cpp/scripts/run_phase2_b0_pair.sh`, `run_phase2_b0_fixed_pair.sh`; domains come from the holdout manifest |
+| Inspect historical leg-lift / multi-step code | `example/cpp/leg_lift/*`; never use it as a Phase 2 route or design source |
 | Inspect retained experiment evidence | `example/cpp/experiments/`, `example/cpp/experiments/CATALOG.md` |
 
 ## Trot controller
@@ -49,6 +55,8 @@ Its action-sequence implementation is split into:
 - Kinematics: `example/cpp/kinematics/go2_forward_kinematics.h`, `go2_inverse_kinematics.h`, `go2_leg_jacobian.h`
 - Gait: `example/cpp/gait/locomotion_kernel.h`, `raibert_trot_kernel.h`, `raibert_footstep_planner.h`, `preview_footstep_horizon.h`, `footstep_mpc.h`
 - Contact / WBC: `example/cpp/contact/contact_*.h`, `contact_wrench_qp.h`, `example/cpp/wbc/dense_qp.h`, `wbc_runtime_gate.h`, `example/cpp/contact/go2_contact_torque_mapping.h`
+- Terrain: `example/cpp/terrain/terrain_model.h`, `terrain_feasibility.h`, `terrain_motion_plan.h`, `terrain_planner.h`, `terrain_control_interface.h`
+- Timing: `example/cpp/trot/lockstep_motion_clock.h`, `lockstep_writer_gate.h`
 - Filtering / frames: `example/cpp/util/velocity_filter.h`, `motion_frame_utils.h`, `example/cpp/contact/contact_state_filter.h`
 
 When a change can alter research semantics, record the affected configuration/evidence and follow [`../CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,43 @@
 # Documentation
 
-For current Phase 2 work, start at [`CURRENT.md`](../CURRENT.md); it is the
-only route and status authority. This page indexes general architecture and
-older accepted Phase 1 evidence only.
+For Phase 2, the authority chain is deliberately small. Start at
+[`CURRENT.md`](../CURRENT.md); every other document is subordinate context,
+implementation guidance, or history.
+
+## Current authority
+
+| Order | Document | Purpose |
+|---:|---|---|
+| 1 | [`CURRENT.md`](../CURRENT.md) | only current route, status, and handoff |
+| 2 | [`AGENTS.md`](../AGENTS.md) | hard execution boundaries |
+| 2 | [`research/PHASE2_ACCEPTANCE.md`](research/PHASE2_ACCEPTANCE.md) | Phase 2 acceptance contract |
+| 3 | [`research/PHASE2_HOLDOUT_MANIFEST.json`](research/PHASE2_HOLDOUT_MANIFEST.json) | frozen profiles, domains, and holdouts |
+| 4 | [`research/evidence/`](research/evidence/), [`../example/cpp/tools/`](../example/cpp/tools/) | curated raw evidence and protocol analyzers |
+
+Evidence, Git history, issues, experiment notes, and agent prose never override
+this order.
+
+## Implementation and operation
 
 | Document | Purpose |
 |---|---|
-| [`CURRENT.md`](../CURRENT.md) | current Phase 2 route, status, and authority |
-| [`RESEARCH_INDEX.md`](RESEARCH_INDEX.md) | claims, evidence, and claim boundary |
-| [`RESEARCH_HISTORY.md`](RESEARCH_HISTORY.md) | milestone history |
-| [`ARCHITECTURE.md`](ARCHITECTURE.md) | simulator/controller runtime and control architecture |
-| [`CODE_GUIDE.md`](CODE_GUIDE.md) | source-level navigation for contributors |
-| [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) | environment, build, smoke checks, and evidence-reproduction rules |
-| [`WBC_MPC.md`](WBC_MPC.md) | 18-DoF ID-WBC + SRBD MPC (`--wbc-full`) |
-| [`SPEED_1MPS_ACCEPTANCE_2026-08-21.md`](SPEED_1MPS_ACCEPTANCE_2026-08-21.md) | Branch-scoped 1 m/s acceptance protocol and evidence |
-| [`NATURAL_GAIT_1MPS_ACCEPTANCE_2026-08-21.md`](NATURAL_GAIT_1MPS_ACCEPTANCE_2026-08-21.md) | 1 m/s natural-trot profile, metrics, and repeatability evidence |
-| [`RUNNING_GAIT_1MPS_ACCEPTANCE_2026-08-21.md`](RUNNING_GAIT_1MPS_ACCEPTANCE_2026-08-21.md) | 1 m/s low-duty running-trot profile, stop handoff, and repeatability evidence |
-| [`TROT_STRAIGHT_RUNNING_RELEASE_2026-08-21.md`](TROT_STRAIGHT_RUNNING_RELEASE_2026-08-21.md) | 当前直线稳定基线、高速跑态发布配置、验收口径与失败边界 |
-| [`SUSTAINED_RUNNING_3MPS_ACCEPTANCE_2026-08-22.md`](SUSTAINED_RUNNING_3MPS_ACCEPTANCE_2026-08-22.md) | branch-scoped 3 m/s running-trot profile, gait-specific acceptance, and three-repeat evidence |
-| [`upstream/`](upstream/) | preserved upstream Unitree MuJoCo README files |
-| [TROT_RELEASE_METRICS_2026-08-21.txt](TROT_RELEASE_METRICS_2026-08-21.txt) | 发布重复实验的简表、边界探针和视频文件名 |
-| [TROT_RELEASE_DELIVERY_README_2026-08-21.txt](TROT_RELEASE_DELIVERY_README_2026-08-21.txt) | OneDrive 最小交付包说明 |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | simulator/controller data flow and module boundaries |
+| [`CODE_GUIDE.md`](CODE_GUIDE.md) | smallest source entrypoint for a change |
+| [`REPRODUCIBILITY.md`](REPRODUCIBILITY.md) | build, test, experiment lock, and evidence rules |
+| [`WBC_MPC.md`](WBC_MPC.md) | Phase 1 ID-WBC and SRBD-MPC implementation |
+| [`../example/cpp/README.md`](../example/cpp/README.md) | C++ build and runtime entrypoints |
+| [`../example/cpp/scripts/README.md`](../example/cpp/scripts/README.md) | runner lifecycle and Phase 2-safe entrypoints |
+| [`../example/cpp/tools/analysis/INDEX.md`](../example/cpp/tools/analysis/INDEX.md) | analyzer lifecycle and scope |
+
+## Claims and history
+
+| Location | Meaning |
+|---|---|
+| [`RESEARCH_INDEX.md`](RESEARCH_INDEX.md) | accepted repository claims and boundaries |
+| [`RESEARCH_HISTORY.md`](RESEARCH_HISTORY.md) | milestone history, including rejected work |
+| [`validation/`](validation/) | accepted Phase 1 protocols and revalidations |
+| [`../example/cpp/experiments/CATALOG.md`](../example/cpp/experiments/CATALOG.md) | retained historical experiment artifacts |
+| [`upstream/`](upstream/) | preserved upstream documentation |
+
+Dated protocol/delivery files in `docs/` are historical Phase 1 records unless
+`CURRENT.md` explicitly adopts them. They cannot define Phase 2 work.

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -1,46 +1,70 @@
 # Reproducibility
 
-This repository combines inherited simulator/runtime code, research-specific C++ control code, and retained experiment artifacts. Reproducibility has two layers: rebuilding the controller stack and reconstructing the evidence behind a specific research claim.
+Start with [`CURRENT.md`](../CURRENT.md). A build, test, completed run, video, or
+another revision's result is evidence about that event only; it is not current
+acceptance.
 
 ## Environment
 
-The research environment used MuJoCo 3.3.6 and Unitree SDK2 on Linux/WSL2. The C++ targets also depend on CMake, Eigen, yaml-cpp, spdlog/fmt, Boost, GLFW/OpenGL, and the dependencies required by the upstream Unitree simulator.
+The reference stack uses Linux/WSL2, MuJoCo 3.3.6, Unitree SDK2, CMake, Eigen,
+yaml-cpp, spdlog/fmt, Boost, GLFW, and OpenGL. The bootstrap helper
+`scripts/setup_ubuntu_env.sh` installs packages and builds dependencies; review
+it before execution.
 
-`scripts/setup_ubuntu_env.sh` is a bootstrap helper for a clean Ubuntu environment. Review it before execution: it installs system packages, downloads MuJoCo, clones/builds Unitree SDK2 when needed, and builds the simulator and C++ examples.
+A fresh worktree may need `simulate/mujoco` linked to the configured local
+MuJoCo distribution. That is environment setup, not a source change.
 
-## Build from a configured checkout
+## Build and tests
+
+From the repository root:
 
 ```bash
 cmake -S simulate -B simulate/build
-cmake --build simulate/build -j"$(nproc)"
+cmake --build simulate/build -j2
+ctest --test-dir simulate/build --output-on-failure
 
 cmake -S example/cpp -B example/cpp/build
-cmake --build example/cpp/build -j"$(nproc)"
+cmake --build example/cpp/build -j2
+ctest --test-dir example/cpp/build --output-on-failure
 ```
 
-Basic kinematics checks:
+These commands verify compilation and registered tests. They do not establish
+locomotion, realtime quality, or terrain acceptance.
+
+## Phase 2 development runs
+
+Before running, record the exact SHA and confirm the worktree is clean. Timed
+simulations must hold `/tmp/go2_mujoco_experiment.lock`. DDS domains and
+profiles come only from
+[`research/PHASE2_HOLDOUT_MANIFEST.json`](research/PHASE2_HOLDOUT_MANIFEST.json).
 
 ```bash
-./example/cpp/build/test_go2_forward_kinematics
-./example/cpp/build/test_go2_inverse_kinematics
+flock /tmp/go2_mujoco_experiment.lock \
+  bash example/cpp/scripts/run_phase2_b0_pair.sh <profile> development 0
+
+flock /tmp/go2_mujoco_experiment.lock \
+  bash example/cpp/scripts/run_phase2_b0_fixed_pair.sh development 0
 ```
 
-The simulator/controller pair inherits the DDS/runtime assumptions of the Unitree stack. See `example/cpp/README.md` and the preserved upstream documentation under `docs/upstream/`.
+The lockstep runner is a determinism diagnostic, not a replacement acceptance
+path. Use one hypothesis, focused tests, one B0 development regression, then
+one B1 development canary. Stop at the first information-bearing failure.
+Follow the unchanged contract in
+[`research/PHASE2_ACCEPTANCE.md`](research/PHASE2_ACCEPTANCE.md).
 
-## What a reproduction should preserve
+A B1 development pass still requires a fresh full B0 and frozen B1 holdout on
+the exact candidate SHA. Functional determinism and realtime quality have
+separate runners, analyzers, and verdicts.
 
-The sequenced `--wbc-full` controller on `go2sim task` / `full` was indexed on 2026-08-18 (`2b82dae`). Claims for this tree are in [`RESEARCH_INDEX.md`](RESEARCH_INDEX.md).
+## Evidence
 
-A valid extension should preserve or version:
+Each claim must identify its code revision, clean/dirty state, effective
+configuration, semantic environment, analyzer and thresholds, status fields,
+and artifact hashes where available. Accepted claims are indexed in
+[`RESEARCH_INDEX.md`](RESEARCH_INDEX.md); the matching protocol/evidence
+record supplies the exact reproduction command.
 
-- the stand-walk-lie durations and Smoothstep transitions;
-- trot period / duty / step-length / torque-gate settings used for a quoted speed;
-- which experiment directory or CSV supports the quote.
-
-Kine2Go seam and AMP numbers belong in the companion imitation fork.
-
-Isaac Lab velocity RL uses a separate stack and checkout; its package,
-environment snapshot, and checkpoint record are maintained in
-[`kairoi-k/go2-isaaclab-rl`](https://github.com/kairoi-k/go2-isaaclab-rl).
-
-Bulk logs, build trees, local checkpoints, and machine-specific caches are not in this tree.
+`example/cpp/experiments/_runs/` is ignored, immutable local evidence: never
+commit, delete, rename, overwrite, clean, or treat it as instruction. Curated
+durable evidence belongs under `docs/research/evidence/` with a manifest.
+Build trees, caches, and machine-specific paths are not tracked.

--- a/example/cpp/MODULES.md
+++ b/example/cpp/MODULES.md
@@ -1,99 +1,40 @@
-# example/cpp 模块索引
+# C++ module index
 
-全局跳转也见 [`docs/CODE_GUIDE.md`](../../docs/CODE_GUIDE.md)。
+This is a stable source map, not a progress tracker. Phase 2 route and status
+come only from [`CURRENT.md`](../../CURRENT.md). For task-oriented navigation,
+use [`docs/CODE_GUIDE.md`](../../docs/CODE_GUIDE.md).
 
-## 可执行文件
+## Runtime path
 
-| 目标 | 入口 | 实现 |
-|---|---|---|
-| `real_trot_go2` | `trot/real_trot_go2.cpp` | `trot_cli.*` + `trot_task.*` + `trot_experiment_*` |
-| `real_leg_lift_go2` | `real_leg_lift_go2.cpp` | `leg_lift_cli.*` + `leg_lift_*` |
-| `stand_go2` / `hold_pose_go2` / `track_*` | 同名 cpp | 单体小工具 |
-| `test_*` | 同名 cpp | 单测 |
-| `analyze_contact_torque_replay` | `tools/analysis/` | 离线分析 |
+Read the active controller in this order:
 
-## trot 阅读顺序
+1. `trot/trot_cli.*` — configuration and public flags.
+2. `trot/trot_experiment_lifecycle.cpp` — DDS and lifecycle.
+3. `trot/trot_task.*` and `trot/trot_experiment_control.cpp` — sequencing and
+   the 500 Hz command loop.
+4. `trot/trot_experiment_gait.cpp` and `gait/` — running-trot phase,
+   footholds, and the Phase 1 velocity path.
+5. `terrain/` — sensor-derived terrain model, feasibility, and plan interfaces.
+6. `trot/trot_experiment_wbc.cpp`, `wbc/`, `contact/`, and `kinematics/`
+   — SRBD MPC, ID-WBC, contact, and robot math.
+7. `trot/trot_experiment_diagnostics.cpp` and `trot/lockstep_*` — status,
+   logging, and timing diagnostics.
 
-1. `trot/trot_cli.cpp` — 参数从哪来
-2. `trot/trot_task.*` — 站立/行走/趴下
-3. `trot/trot_experiment.h` — 剩余运行时状态
-4. `trot/trot_experiment_control.cpp` 搜 `SECTION:` — 主环
-5. `trot/trot_experiment_gait.cpp` / `gait/raibert_trot_kernel.h` — 脚点
-6. `trot/trot_experiment_wbc.cpp` — 力/力矩
-7. `trot/trot_experiment_diagnostics.cpp` — 门禁与 CSV
+## Executables and verification
 
-## leg-lift 阅读顺序
-
-1. `leg_lift_cli.cpp`
-2. `leg_lift_types.h` — StepConfig / 常量
-3. `leg_lift_control.cpp` 搜 `SECTION:`
-4. `leg_lift_world.cpp` — 世界系反馈
-5. `leg_lift_diagnostics.cpp`
-
-## 约定
-
-- Named `go2_*` directories stay under `experiments/`
-- Other runs → `experiments/_runs/`
-- Batch scripts → `scripts/batch/`
-
-## 本地 include 关系（生成）
-
-- `leg_lift_cli.cpp` → `leg_lift_cli.h`
-- `leg_lift_control.cpp` → `leg_lift_experiment.h`, `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`
-- `leg_lift_diagnostics.cpp` → `leg_lift_experiment.h`, `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`
-- `leg_lift_lifecycle.cpp` → `leg_lift_experiment.h`, `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`
-- `leg_lift_world.cpp` → `leg_lift_experiment.h`, `go2_forward_kinematics.h`, `go2_inverse_kinematics.h`
-- `real_leg_lift_go2.cpp` → `leg_lift_cli.h`, `leg_lift_experiment.h`
-- `real_trot_go2.cpp` → `trot_cli.h`, `trot_experiment.h`
-- `trot_cli.cpp` → `trot_cli.h`
-- `trot_experiment_control.cpp` → `trot_experiment.h`, `contact_wrench_projected_allocator.h`, `contact_state_filter.h`, `go2_contact_torque_mapping.h`, `go2_inverse_kinematics.h`, `motion_frame_utils.h`
-- `trot_experiment_diagnostics.cpp` → `trot_experiment.h`, `contact_wrench_projected_allocator.h`, `contact_state_filter.h`, `go2_contact_torque_mapping.h`, `go2_inverse_kinematics.h`, `motion_frame_utils.h`
-- `trot_experiment_gait.cpp` → `trot_experiment.h`, `contact_wrench_projected_allocator.h`, `contact_state_filter.h`, `go2_contact_torque_mapping.h`, `go2_inverse_kinematics.h`, `motion_frame_utils.h`
-- `trot_experiment_lifecycle.cpp` → `trot_experiment.h`, `contact_wrench_projected_allocator.h`, `contact_state_filter.h`, `go2_contact_torque_mapping.h`, `go2_inverse_kinematics.h`, `motion_frame_utils.h`
-- `trot_experiment_wbc.cpp` → `trot_experiment.h`, `trot_true_dynamics.h`, `contact_wrench_projected_allocator.h`, `contact_state_filter.h`, `go2_contact_torque_mapping.h`, `go2_inverse_kinematics.h`, `motion_frame_utils.h`
-
-
-## leg_lift 相位方法（持续拆分中）
-
-已抽出（`leg_lift_control.cpp`）：
-
-- `PhaseStandUp` / `PhaseStandSettle` / `PhaseWeightShift`
-- `PhaseFootLift` / `PhaseFootSwing` / `PhaseLandingHold` / `PhaseBodyReturn` / `PhaseFootLowerActive`
-- 上下文：`LowCmdScratch`（`cycle_time` 等嵌套相位共享量）
-
-主链剩余：仅 publish/log 尾段（`SECTION:` 跳转）。
-
-## 清晰化进度快照
-
-- 布局：`apps/` `trot/` `gait/` `kinematics/` `contact/` `wbc/` `util/` `leg_lift/` `tests/`
-- trot：`TrotTask` 拥有站立/行走/趴下；`TrotExperiment` 保留 DDS/gait/WBC/诊断
-- leg_lift：main/CLI/模块拆分完成；相位已抽 StandUp/Settle/WeightShift/FootLift/FootSwing/LandingHold/BodyReturn
-- 单测：example/cpp/build/test_* 应全绿
-
-## trot 相位方法
-
-- `TrotTask::PhaseLieDown` / `PhaseStandUp` / `PhaseStandSettle` / `PhaseStopToStand` / `BeginGait`（`trot/trot_task.cpp`）
-- 主链其余段：快照/时钟/WBC 判定/gait 执行/命令写入/诊断
-
-## 体量（约，自动更新）
-
-| 项 | 值 |
+| Item | Location |
 |---|---|
-| leg `LowCmdWrite` | 218 行（含 AUTO-TOC） |
-| trot `LowCmdWrite` | 107 行（含 AUTO-TOC） |
-| leg Phase* | 11 |
-| trot Phase* | 6 |
-| mains | ~50 行级 |
+| Main controller | `trot/real_trot_go2.cpp` |
+| Stand/hold/track utilities | `apps/` |
+| Historical leg-lift executable | `leg_lift/real_leg_lift_go2.cpp` |
+| Tests | `tests/` |
+| Runners | `scripts/` |
+| Analyzers | `tools/`, `tools/analysis/` |
+| Retained artifacts | `experiments/`, indexed by `experiments/CATALOG.md` |
 
-## trot 主环已抽方法（`trot_experiment_control.cpp`）
+The `leg_lift/` action sequence and its configuration files are retained only
+for historical experiments. They must not be used as a Phase 2 implementation,
+fallback, or design source. There is no `scripts/batch/` entrypoint.
 
-- `SnapshotState` / `MotionClockStep` / `ComputeWbcPrimaryActive`
-- `PhaseRunGait` / `WriteMotorCommands`（wbc 主控 vs 位置混合）
-- `UpdateWbcShadowAndTorqueFf` / `UpdateJointVelocityFeedforward` / `UpdateGaitWorldDiagnostics`
-- 相位：`PhaseLieDown` / `PhaseStandUp` / `PhaseStandSettle` / `PhaseStartGait` / `PhaseStopToStand`
-
-## leg_lift 主环已抽方法（`leg_lift_control.cpp`）
-
-- `MotionClockStep` / `TempoGovernorScale` / `UpdateAttitudeFeedback`
-- `ApplyTaskSpaceIk` / `WriteMotorCommands` / `PublishLowCmdWithCrc`
-- 相位：StandUp / StandSettle / WeightShift / FootLift / FootSwing / FootLowerActive / LandingHold / BodyReturn / BetweenCycles / NeutralSettle / TerminalCorrection
+Generated include graphs, line counts, and refactor-progress snapshots are
+intentionally omitted because the source and CMake graph are authoritative.

--- a/example/cpp/README.md
+++ b/example/cpp/README.md
@@ -1,68 +1,66 @@
 # Go2 C++ control stack
 
-This directory contains the primary model-based locomotion implementation and its retained research artifacts.
+This directory contains the model-based locomotion controller, tests, runners,
+and retained evidence. Before any Phase 2 action, read
+[`CURRENT.md`](../../CURRENT.md); it is the sole route/status authority.
 
-## Build
+## Build and test
 
 From the repository root, after MuJoCo and Unitree SDK2 are configured:
 
 ```bash
 cmake -S example/cpp -B example/cpp/build
-cmake --build example/cpp/build -j"$(nproc)"
-```
-
-The main locomotion target is `real_trot_go2`. Kinematics and other test targets are defined in `CMakeLists.txt`. `test_go2_forward_kinematics` is built only when `simulate/mujoco/lib/libmujoco.so` is present.
-
-```bash
-cmake -S example/cpp -B example/cpp/build
-cmake --build example/cpp/build -j"$(nproc)"
+cmake --build example/cpp/build -j2
 ctest --test-dir example/cpp/build --output-on-failure
 ```
 
-See [`../../docs/REPRODUCIBILITY.md`](../../docs/REPRODUCIBILITY.md) for environment assumptions and simulator build notes.
+The main target is `real_trot_go2`. Some tests require
+`simulate/mujoco/lib/libmujoco.so`. See
+[`docs/REPRODUCIBILITY.md`](../../docs/REPRODUCIBILITY.md) for environment,
+experiment-lock, and acceptance rules.
 
-## Running the simulator/controller pair
+## Phase 2 entrypoints
 
-`example/cpp/scripts/go2sim` wraps the simulator and controller launch used by the research experiments. Examples:
+Only the following runners belong to the current Phase 2 development workflow:
 
-```bash
-bash example/cpp/scripts/go2sim task
-bash example/cpp/scripts/go2sim task --view
-bash example/cpp/scripts/go2sim full
-bash example/cpp/scripts/go2sim walk
-bash example/cpp/scripts/go2sim turn 0.3
-```
-
-`task` and `full` are `--wbc-full --tau-limit 35`. `walk` is the older `--wbc-primary` path. The runner uses dedicated DDS domain IDs. Inspect it and `scripts/run_trot.sh` before adapting the setup to another machine or network.
-
-## Source layout
-
-Sources live in named modules under `example/cpp/`. `#include "foo.h"` still works because CMake adds every module directory.
-
-| Area | Files |
+| Runner | Role |
 |---|---|
-| Entry point / CLI | `trot/real_trot_go2.cpp`, `trot/trot_cli.*` |
-| Stand / walk / lie sequencer | `trot/trot_task.*` |
-| Controller lifecycle | `trot/trot_experiment_lifecycle.cpp` |
-| 500 Hz control loop | `trot/trot_experiment_control.cpp` |
-| Gait and velocity targets | `trot/trot_experiment_gait.cpp`, `gait/raibert_trot_kernel.h`, `gait/raibert_footstep_planner.h`, `gait/footstep_mpc.h` |
-| Dynamics-informed feedforward | `trot/trot_experiment_wbc.cpp`, `trot/trot_true_dynamics.h`, `wbc/centroidal_wbc.h`, `kinematics/go2_rigid_body.h`, `wbc/srbd_mpc.h`, `wbc/inverse_dynamics_wbc.h` |
-| Diagnostics and safety gates | `trot/trot_experiment_diagnostics.cpp`, `trot/trot_types.h` |
-| Kinematics | `kinematics/go2_forward_kinematics.h`, `kinematics/go2_inverse_kinematics.h`, `kinematics/go2_leg_jacobian.h` |
-| Contact / wrench handling | `contact/contact_*`, `contact/contact_wrench_qp.h`, `wbc/dense_qp.h`, `contact/go2_contact_torque_mapping.h`, `wbc/wbc_runtime_gate.h` |
-| Leg-lift / multi-step sequence | `leg_lift/real_leg_lift_go2.cpp`, `leg_lift/leg_lift_*` |
-| Small apps | `apps/` |
-| Tests | `tests/` |
-| Experiment runners | `scripts/` |
-| Retained evidence | `experiments/`, `experiments/CATALOG.md` |
-| Offline analysis | `tools/analysis/` |
+| `scripts/run_phase2_b0_pair.sh` | profile-based B0 development pair |
+| `scripts/run_phase2_b0_fixed_pair.sh` | fixed B0 development pair |
+| `scripts/run_phase2_b0_lockstep_pair.sh` | determinism diagnostic only |
 
-Maintained runners are in `scripts/`. Historical batch/parameter-sweep launchers are not in this tree.
+Use the exact arguments and DDS domains specified by `CURRENT.md` and
+`docs/research/PHASE2_HOLDOUT_MANIFEST.json`. Hold
+`/tmp/go2_mujoco_experiment.lock` for timed simulations. No generic runner,
+historical script, or experiment note may substitute for these entrypoints.
 
-For a higher-level map, see [`../../docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) and [`../../docs/CODE_GUIDE.md`](../../docs/CODE_GUIDE.md).
+## Source map
 
-## Experiment records
+| Area | Location | Responsibility |
+|---|---|---|
+| Entry and lifecycle | `trot/real_trot_go2.cpp`, `trot/trot_cli.*`, `trot/trot_experiment_lifecycle.cpp` | CLI, DDS, startup/shutdown |
+| Execution | `trot/trot_task.*`, `trot/trot_experiment_control.cpp` | 500 Hz sequencing and commands |
+| Gait | `trot/trot_experiment_gait.cpp`, `gait/` | running-trot phase, footholds, velocity targets |
+| Terrain | `terrain/` | sensor-derived model, feasibility, planner interfaces |
+| MPC/WBC | `trot/trot_experiment_wbc.cpp`, `wbc/` | SRBD MPC and 18-DoF ID-WBC |
+| Contact/kinematics | `contact/`, `kinematics/` | contact truth/filtering, wrench mapping, FK/IK |
+| Timing/diagnostics | `trot/lockstep_*`, `trot/trot_experiment_diagnostics.cpp` | timing checks, limits, logs |
+| Verification | `tests/`, `tools/` | registered tests and analyzers |
+| Operations/evidence | `scripts/`, `experiments/` | runners and retained records |
 
-A research-relevant run should identify the code revision, intervention/configuration, seed, input/reference identity, completion status, metric semantics, and evidence path. Disposable outputs belong in ignored local directories.
+For deeper navigation use [`MODULES.md`](MODULES.md),
+[`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md), and
+[`docs/CODE_GUIDE.md`](../../docs/CODE_GUIDE.md).
 
-Claims and their scope are in [`../../docs/RESEARCH_INDEX.md`](../../docs/RESEARCH_INDEX.md). History: [`../../docs/RESEARCH_HISTORY.md`](../../docs/RESEARCH_HISTORY.md).
+## Historical utilities
+
+`scripts/go2sim`, sustained-running wrappers, and the standalone
+`leg_lift/` executable remain useful for their documented Phase 1 or historical
+scope. The leg-lift/multi-step sequence is not a Phase 2 route or design source.
+Do not infer current status from a script name or retained artifact.
+
+Research-relevant runs must record revision, configuration, semantic
+environment, analyzer, result, and evidence path. Raw `experiments/_runs/`
+content is ignored immutable local evidence. Claims and history live in
+[`docs/RESEARCH_INDEX.md`](../../docs/RESEARCH_INDEX.md) and
+[`docs/RESEARCH_HISTORY.md`](../../docs/RESEARCH_HISTORY.md).

--- a/example/cpp/configs/README.md
+++ b/example/cpp/configs/README.md
@@ -1,36 +1,29 @@
-# 序列配置
+# Controller configurations
 
-供 `run_leg_sequence.sh` / `real_leg_lift_go2 --sequence-file` 使用。
+For Phase 2, configuration and DDS allocation come only from
+[`CURRENT.md`](../../../CURRENT.md) and
+`docs/research/PHASE2_HOLDOUT_MANIFEST.json`.
 
-典型配置：
+## Versioned runtime profiles
 
-- `go2_four_step_fr_rl_fl_rr.txt` — 对角四步
-
-格式见加载函数 `LoadStepSequence`（`leg_lift_types.h`）：每步指定抬腿、重心偏移、抬脚高、摆动与机身前进等。
-
-跑法示例：
-
-```bash
-bash example/cpp/scripts/run_leg_sequence.sh 60 \
-  go2_four_step_diagonal_rrx10_2026-08-02 \
-  example/cpp/configs/go2_four_step_fr_rl_fl_rr.txt
-```
-
-## Versioned simulation profiles
-
-JSON profiles in `profiles/` are schema-versioned and keep ordered controller
-arguments beside the semantic environment snapshot used by a run. The
-canonical `go2sim` launcher accepts either `--profile FILE` or the
-`GO2_PROFILE_PATH` environment variable:
+JSON files in `profiles/` store a schema version, ordered controller
+arguments, and semantic environment. The launcher accepts `--profile FILE` or
+`GO2_PROFILE_PATH`:
 
 ```bash
 bash example/cpp/scripts/go2sim \
   --profile example/cpp/configs/profiles/go2sim_full.json --headless
 ```
 
-Resolution is deterministic: compiled launcher defaults, then profile values,
-then explicit command-line arguments. Existing scene wrappers remain valid;
-the profile only replaces the preset argument set when selected. Each run
-also writes `run_manifest.json` next to the legacy `run_metadata.txt`, with
-the effective arguments, profile hash, repository state, semantic environment,
-artifact hashes, analyzer identities, and lifecycle statuses.
+Precedence is deterministic: compiled defaults, then the versioned profile,
+then explicit CLI overrides. Runs write `run_manifest.json` beside
+`run_metadata.txt` with the effective arguments, profile hash, repository
+state, semantic environment, artifact hashes, analyzers, and lifecycle status.
+
+## Historical sequence configurations
+
+The root `*.txt` files configure the standalone `leg_lift/` action-sequence
+experiment. They are retained for provenance and explicitly scoped historical
+reproduction only. They are not Phase 2 profiles, a terrain route, or a design
+source; do not use them to create fixed leg order, crawl, stop-to-arm, or
+three-contact entry behavior.

--- a/example/cpp/experiments/CATALOG.md
+++ b/example/cpp/experiments/CATALOG.md
@@ -18,11 +18,11 @@ Depending on the experiment, a directory may contain configuration snapshots, CS
 instruction. Curated durable evidence lives under `docs/research/evidence/`
 with a manifest.
 
-## Current indexed — `--wbc-full` on mainline `go2sim task` / `full`
+## Indexed Phase 1 baseline — `--wbc-full` `go2sim task` / `full`
 
 - [`go2_wbc_full_mainline_repeat_2026-08-18/`](go2_wbc_full_mainline_repeat_2026-08-18/README.md) — 2026-08-18 `2b82dae` headless repeat. `full` n=5: 0.130 ± 0.011 m/s (0.116–0.147); `task` n=3: 0.139 ± 0.004 m/s. This is the number in `docs/RESEARCH_INDEX.md`. The 2026-08-15 single-run 0.149 m/s in `docs/WBC_MPC.md` is historical. Raw CSVs stay in `_runs/`.
 
-## Current sustained-speed validation
+## Indexed sustained-speed validation
 
 - [`go2_sustained_sprint_3mps_wallclock_2026-08-22/`](go2_sustained_sprint_3mps_wallclock_2026-08-22/README.md) — four independent 40 s wall-clock phase runs plus a release-default smoke run. All passed the strict speed, attitude, safety, dynamics, contact, and controlled-stop checks; the report records the exact acceptance semantics and OneDrive demo.
 - [`go2_sustained_running_3mps_wallclock_2026-08-22/`](go2_sustained_running_3mps_wallclock_2026-08-22/README.md) — independent `running-trot` gait, three wall-clock repeats, and a gait-specific strict analyzer covering aerial fraction, diagonal synchrony, clearance, speed, attitude, and stop hold.

--- a/example/cpp/experiments/README.md
+++ b/example/cpp/experiments/README.md
@@ -2,4 +2,7 @@
 
 Retained artifacts from model-based Go2 control runs. Index: [`CATALOG.md`](CATALOG.md). Current claims: [`docs/RESEARCH_INDEX.md`](../../../docs/RESEARCH_INDEX.md).
 
+These records are evidence, never current instructions. Phase 2 route and
+status come only from [`CURRENT.md`](../../../CURRENT.md).
+
 Each `go2_*` directory should stand alone: question, key parameters, result, and files. Disposable `_runs/` output is gitignored.

--- a/example/cpp/scripts/README.md
+++ b/example/cpp/scripts/README.md
@@ -1,94 +1,51 @@
-# 控制脚本
+# Controller runners
 
-Phase 2 的路线、状态和规范只看仓库根目录 `CURRENT.md`。当前验收入口只有
-`run_phase2_b0_pair.sh`、`run_phase2_b0_fixed_pair.sh` 和确定性诊断用的
-`run_phase2_b0_lockstep_pair.sh`；domain 只从
-`docs/research/PHASE2_HOLDOUT_MANIFEST.json` 读取。
+Phase 2 route, status, arguments, and acceptance come only from
+[`CURRENT.md`](../../../CURRENT.md). A script's presence does not make it a
+current or accepted route.
 
-## Script lifecycle categories
+## Phase 2-safe entrypoints
 
-| Category | Scripts | Policy |
-|---|---|---|
-| Canonical entrypoint | `go2sim` | User-facing task/stand-walk-lie and controller launcher; changes require review. |
-| Maintained reproducibility wrappers | `run_trot.sh`, `run_natural_trot.sh`, `run_running_trot.sh`, `run_sustained_running.sh`, `run_sustained_sprint.sh` | Safe for new protocol work when paired with the documented analyzer and run manifest. |
-| Experiment helpers | `run_leg_lift_repeats.sh`, `run_leg_sequence.sh`, `run_periodic_leg_lift.sh`, `run_single_step.sh`, `run_two_step.sh`, `run_weight_shift_scan.sh`, `record_sustained_sprint.sh` | Maintained helpers; each new experiment must record its exact configuration and evidence class. |
-| Historical compatibility / capture helpers | `record_periodic_leg_lift.sh`, `record_reactive_acceptance.sh` | Retained for provenance or capture workflows; do not treat them as canonical acceptance entrypoints without a current protocol record. |
-
-其余脚本不能改变 Phase 2 路线或验收结论。新 wrapper 必须记录有效参数、
-语义环境、输出目录和 analyzer。
-
-## 维护入口
-
-| 脚本 | 用途 |
+| Script | Scope |
 |---|---|
-| `go2sim` | 首选一键行走、快档、完整任务、扰动与负载入口 |
-| `run_trot.sh` | trot 底层启动（`go2sim` 调用） |
-| `run_leg_sequence.sh` | 多步抬腿 / 换腿序列 |
-| `run_leg_lift_repeats.sh` | 抬腿重复实验 |
-| `run_periodic_leg_lift.sh` | 周期抬腿 |
-| `run_single_step.sh` / `run_two_step.sh` | 单步、两步实验 |
-| `run_weight_shift_scan.sh` | 重心扫描 |
-| `record_periodic_leg_lift.sh` | 周期抬腿录制（需显式配置捕获工具目录） |
-| `run_natural_trot.sh` | 固定参数、直线约束的自然小跑基线入口 |
-| `run_running_trot.sh` | 固定参数、直线约束的低占空比高速跑态入口 |
-| `run_sustained_running.sh` | 墙钟相位、3 m/s 级持续 running-trot 入口 |
+| `run_phase2_b0_pair.sh` | profile-based B0 development pair |
+| `run_phase2_b0_fixed_pair.sh` | fixed B0 development pair |
+| `run_phase2_b0_lockstep_pair.sh` | determinism diagnostic; not acceptance |
 
-自动环境感知验收：`../tools/analyze_auto_environment.py` 会检查高度图新鲜度、自动事件、参考方向、姿态、WBC 残差和真实障碍物接触。
-物理冲击→急停验收：`../tools/analyze_auto_impact.py`；它将 simulator.log 的施力时刻与 data.csv 的 state_tick_s 对齐并输出严格报告。
-```bash
-bash example/cpp/scripts/go2sim walk --view
-bash example/cpp/scripts/go2sim walk
-bash example/cpp/scripts/go2sim fast --view
-```
+DDS domains come only from
+`docs/research/PHASE2_HOLDOUT_MANIFEST.json`. Timed simulations must hold
+`/tmp/go2_mujoco_experiment.lock`. Use the commands in `CURRENT.md`; do not
+invent a profile, domain, retry loop, or alternative runner.
 
-实验输出：名称 `go2_*` → `experiments/`；其它临时输出 →
-`experiments/_runs/`。Phase 2 DDS domain 由冻结 manifest 分配。
+## Maintained non-Phase-2 runners
 
-历史批量扫参和机器专属启动器不在 git。
+| Script | Scope |
+|---|---|
+| `go2sim`, `run_trot.sh` | general/Phase 1 controller launcher |
+| `run_natural_trot.sh`, `run_running_trot.sh` | historical gait protocols |
+| `run_sustained_running.sh`, `run_sustained_sprint.sh` | accepted high-speed protocol reproduction |
+| `record_sustained_sprint.sh` | bounded capture helper |
 
-自然小跑验收：
+Use these only with their matching indexed protocol and analyzer. They cannot
+establish or alter Phase 2 status.
 
-```bash
-bash example/cpp/scripts/run_natural_trot.sh 100 natural_trot_rep1
-python3 example/cpp/tools/analysis/analyze_natural_gait.py \
-  example/cpp/experiments/_runs/natural_trot_rep1 \
-  --min-cruise-speed 0.80 --min-speed-p05 0.60 --min-cycle-count 30
-python3 example/cpp/tools/analysis/analyze_straightness.py \
-  example/cpp/experiments/_runs/natural_trot_rep1
-```
+## Historical action-sequence helpers
 
-需要 GUI 时在末尾加 `--view --camera-follow`；需要换 DDS 域或录制时，
-继续追加 `--domain-id <n>`、`--controller-duration <s>` 等参数。
+`run_leg_lift_repeats.sh`, `run_leg_sequence.sh`,
+`run_periodic_leg_lift.sh`, `run_single_step.sh`, `run_two_step.sh`,
+`run_weight_shift_scan.sh`, `record_periodic_leg_lift.sh`, and
+`record_reactive_acceptance.sh` are retained for provenance or an explicitly
+scoped historical study. They are not Phase 2 entrypoints or design sources.
+Do not use them to construct a crawl, fixed leg order, stop-to-arm transition,
+or three-contact entry gate.
 
-跑态验收：
+## Evidence and changes
 
-```bash
-bash example/cpp/scripts/run_running_trot.sh 100 running_trot_rep1
-python3 example/cpp/tools/analysis/analyze_running_gait.py \
-  example/cpp/experiments/_runs/running_trot_rep1
-```
+Named curated records live under `experiments/go2_*/`. All disposable output
+goes to ignored `experiments/_runs/`, which is immutable local evidence and
+must never be committed, deleted, renamed, overwritten, or treated as
+instruction.
 
-该入口使用 `period=0.26 s`、`duty=0.45`、`step=0.320 m`，形成短暂腾空相；
-末端急停用于验证跑态到四足 WBC 支撑的安全交接。
-
-3 m/s 持续跑态验收：
-
-```bash
-bash example/cpp/scripts/run_sustained_running.sh --headless
-python3 example/cpp/tools/analysis/analyze_sustained_running.py \
-  example/cpp/experiments/_runs/<run-name>
-```
-
-该入口单独使用 `running-trot` 参考，不是对角小跑的改名；验收器还检查
-腾空比例、对角同步、摆腿高度和支撑分布。
-
-两个入口在 WSL 中默认把 MuJoCo 和控制器分别固定到 CPU 2、3；可用
-`TROT_CPU_AFFINITY_SIM`、`TROT_CPU_AFFINITY_CTRL` 覆盖，或设
-`TROT_CPU_AUTOPIN=0` 关闭自动固定。直线验收相对世界 +X，要求横向位置
-p95≤0.10 m、末端≤0.12 m、航向 p95≤8°、横向速度 p95≤0.25 m/s。
-
-## 相关文档
-
-- [`../../../docs/CODE_GUIDE.md`](../../../docs/CODE_GUIDE.md)
-- [`../MODULES.md`](../MODULES.md)
-- [`../../../docs/RESEARCH_INDEX.md`](../../../docs/RESEARCH_INDEX.md)
+A new or changed runner must document its owner protocol, effective arguments,
+semantic environment, output path, analyzer, and lifecycle category. Update
+this file and the analyzer index in the same PR.

--- a/example/cpp/tools/analysis/INDEX.md
+++ b/example/cpp/tools/analysis/INDEX.md
@@ -1,15 +1,33 @@
 # Analysis-tool index
 
-`example/cpp/tools/analysis/` contains both current protocol analyzers and retained diagnostics. “Safe for new work” means the tool has an indexed protocol owner and its thresholds/metric semantics are suitable for a new experiment; it does not mean that it can replace a protocol-specific acceptance analyzer.
+For Phase 2, start with [`CURRENT.md`](../../../../CURRENT.md). Only the frozen
+protocol may select an analyzer or interpret its result. This index classifies
+tools; it cannot create an acceptance route.
+
+| Phase 2 tools | Owner | Use |
+|---|---|---|
+| `../analyze_phase2_b0.py` | `docs/research/PHASE2_ACCEPTANCE.md` | canonical B0 analyzer |
+| `../analyze_phase2_terrain.py` | same frozen contract | B1/B2/B3 terrain analyzer; a pass is candidate evidence only |
+| `../read_phase2_b0_domains.py` | holdout manifest | read frozen DDS allocations |
+| `../compare_lockstep_canary.py` | determinism diagnostics | compare lockstep output; never substitutes for runtime acceptance |
+
+`example/cpp/tools/analysis/` contains accepted Phase 1 analyzers and retained
+diagnostics. “Safe for new work” means safe only inside its named protocol; no
+generic analyzer can replace a target-specific acceptance analyzer.
+
+Other tools one directory above are either operational helpers
+(`profile_cli.py`, `write_run_manifest.py`) or retained Phase 1
+reactive/automatic-environment tooling. They are not Phase 2 analyzers unless
+`CURRENT.md` and the frozen acceptance contract explicitly name them.
 
 | Family / scripts | Protocol owner | State | Safe for new work? |
 |---|---|---|---|
-| `analyze_sustained_running.py`, `analyze_sustained_sprint.py`, `analyze_running_gait.py`, `analyze_speed_acceptance.py`, `analyze_natural_gait.py`, `analyze_straightness.py` | High-speed and natural/straight gait protocols | Current | Yes, with the matching acceptance document |
-| `inspect_speed_profile.py`, `inspect_speed_transition.py`, `inspect_speed_window.py`, `inspect_stop_csv.py`, `summarize_high_speed_acceptance.py`, `summarize_wbc_speed_probe.py` | High-speed evidence review | Current diagnostic | Yes, as supporting analysis; not a standalone acceptance gate |
-| `analyze_leg_lift_repeatability.py`, `analyze_leg_sequence.py`, `analyze_periodic_leg_lift.py`, `analyze_real_leg_lift.py`, `analyze_single_step.py`, `analyze_two_step.py`, `analyze_weight_shift.py`, `analyze_weight_shift_scan.py`, `analyze_locomotion_progress.py` | Low-level action and locomotion experiments | Current/supporting | Yes, with an experiment record |
-| `analyze_base_dynamics_closure.py`, `analyze_base_mass_matrix.py`, `analyze_bounded_dynamic_target.py`, `analyze_dynamic_target_feasibility.py`, `analyze_full_dynamics_closure.py`, `analyze_dynamics_task_replay.py`, `analyze_contact_dynamics.py`, `analyze_contact_ground_truth.py` | Dynamics and ground-truth validation | Current/supporting | Yes, with explicit metric semantics |
-| `analyze_constraint_wrench_truth.py`, `analyze_contact_conditioned_shadow.py`, `analyze_contact_moment_shadow.py`, `analyze_contact_torque_ground_truth_replay.py`, `analyze_task_wrench_gap.py`, `analyze_moment_slack_sweep.py` | Contact/wrench diagnostics | Current diagnostic | Yes, for diagnostics; no unreviewed claim promotion |
-| `analyze_fullbody_wbc_replay.py`, `analyze_rate_aware_fallback.py`, `analyze_replay_torque_continuity.py`, `analyze_sequence_constrained_shadow.py`, `analyze_torque_rate_limit_shadow.py`, `analyze_torque_rate_limit_wrench_shadow.py`, `analyze_wbc_fallback_policy.py`, `analyze_wbc_task_features.py`, `analyze_wbc_torque_replay.py`, `analyze_wbc_wrench_components.py` | WBC/MPC replay and controller diagnostics | Current/supporting | Yes, only as declared replay/diagnostic evidence |
+| `analyze_sustained_running.py`, `analyze_sustained_sprint.py`, `analyze_running_gait.py`, `analyze_speed_acceptance.py`, `analyze_natural_gait.py`, `analyze_straightness.py` | Accepted Phase 1 gait protocols | Phase 1 | Only with the matching frozen Phase 1 document |
+| `inspect_speed_profile.py`, `inspect_speed_transition.py`, `inspect_speed_window.py`, `inspect_stop_csv.py`, `summarize_high_speed_acceptance.py`, `summarize_wbc_speed_probe.py` | High-speed evidence review | Diagnostic | Supporting analysis only |
+| `analyze_leg_lift_repeatability.py`, `analyze_leg_sequence.py`, `analyze_periodic_leg_lift.py`, `analyze_real_leg_lift.py`, `analyze_single_step.py`, `analyze_two_step.py`, `analyze_weight_shift.py`, `analyze_weight_shift_scan.py`, `analyze_locomotion_progress.py` | Historical low-level action experiments | Historical/supporting | No for Phase 2; only for an explicitly scoped historical study |
+| `analyze_base_dynamics_closure.py`, `analyze_base_mass_matrix.py`, `analyze_bounded_dynamic_target.py`, `analyze_dynamic_target_feasibility.py`, `analyze_full_dynamics_closure.py`, `analyze_dynamics_task_replay.py`, `analyze_contact_dynamics.py`, `analyze_contact_ground_truth.py` | Dynamics and ground-truth checks | Diagnostic | Supporting analysis only |
+| `analyze_constraint_wrench_truth.py`, `analyze_contact_conditioned_shadow.py`, `analyze_contact_moment_shadow.py`, `analyze_contact_torque_ground_truth_replay.py`, `analyze_task_wrench_gap.py`, `analyze_moment_slack_sweep.py` | Contact/wrench checks | Diagnostic | Supporting analysis only |
+| `analyze_fullbody_wbc_replay.py`, `analyze_rate_aware_fallback.py`, `analyze_replay_torque_continuity.py`, `analyze_sequence_constrained_shadow.py`, `analyze_torque_rate_limit_shadow.py`, `analyze_torque_rate_limit_wrench_shadow.py`, `analyze_wbc_fallback_policy.py`, `analyze_wbc_task_features.py`, `analyze_wbc_torque_replay.py`, `analyze_wbc_wrench_components.py` | WBC/MPC replay checks | Diagnostic | Supporting analysis only |
 | `perturb_ground_truth_orientation.py`, `perturb_replay_input.py`, `replay_rate_aware_state_machine.py`, `plot_lowcmd_lowstate_tracking.py` | Historical replay/perturbation tooling | Historical/diagnostic | No for new acceptance; preserve for provenance |
 | `analyze_acceleration_consistent_task_target.py`, `analyze_hold_candidate.py`, `analyze_perturbation_robustness.py` | Exploratory task and robustness probes | Historical/supporting | No without a new protocol owner and review |
 

--- a/tools/check_repo_hygiene.py
+++ b/tools/check_repo_hygiene.py
@@ -74,6 +74,35 @@ REQUIRED_FILES = (
     "docs/research/PHASE2_HOLDOUT_MANIFEST.json",
     "example/cpp/experiments/CATALOG.md",
 )
+REQUIRED_DOC_MARKERS = {
+    "README.md": ("CURRENT.md",),
+    "CONTRIBUTING.md": ("CURRENT.md", "AGENTS.md"),
+    "docs/README.md": (
+        "CURRENT.md",
+        "PHASE2_ACCEPTANCE.md",
+        "PHASE2_HOLDOUT_MANIFEST.json",
+    ),
+    "docs/ARCHITECTURE.md": ("CURRENT.md", "not a Phase 2 route"),
+    "docs/REPRODUCIBILITY.md": (
+        "CURRENT.md",
+        "/tmp/go2_mujoco_experiment.lock",
+        "PHASE2_HOLDOUT_MANIFEST.json",
+    ),
+    "docs/CODE_GUIDE.md": ("CURRENT.md", "PHASE2_ACCEPTANCE.md"),
+    "example/cpp/README.md": ("CURRENT.md", "run_phase2_b0_pair.sh"),
+    "example/cpp/MODULES.md": ("CURRENT.md", "not be used as a Phase 2"),
+    "example/cpp/configs/README.md": ("CURRENT.md", "not Phase 2 profiles"),
+    "example/cpp/scripts/README.md": (
+        "CURRENT.md",
+        "run_phase2_b0_pair.sh",
+        "run_phase2_b0_fixed_pair.sh",
+    ),
+    "example/cpp/tools/analysis/INDEX.md": (
+        "CURRENT.md",
+        "analyze_phase2_b0.py",
+        "analyze_phase2_terrain.py",
+    ),
+}
 PHASE2_SOURCE_PREFIXES = (
     "example/cpp/gait/",
     "example/cpp/terrain/",
@@ -120,6 +149,16 @@ def main() -> int:
     for rel in REQUIRED_FILES:
         if not (root / rel).is_file():
             problems.append(f"missing required file: {rel}")
+
+    for rel, markers in REQUIRED_DOC_MARKERS.items():
+        path = root / rel
+        if not path.is_file():
+            problems.append(f"missing navigation document: {rel}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for marker in markers:
+            if marker not in text:
+                problems.append(f"missing required guidance in {rel}: {marker}")
 
     for rel in tracked_files(root):
         path = root / rel


### PR DESCRIPTION
Summary

- Makes CURRENT.md the unmistakable handoff entry throughout README, docs, C++ guides, scripts, configs, analyzers, and contribution flow.
- Reclassifies leg-lift and scripted multi-step material as historical and removes stale module snapshots and dead paths.
- Adds CI-enforced markers for the authority chain, Phase 2 manifest, experiment lock, analyzers, and historical boundaries.
- Records the 2026-09-04 branch, raw-evidence, retired-route, and release cleanup in CHANGELOG.

Research-semantic impact

Documentation and repository hygiene only. No controller, simulator, protocol, threshold, evidence, or accepted claim changed.

Validation

- git diff --check
- python3 tools/check_repo_hygiene.py
- ctest --test-dir example/cpp/build --output-on-failure: 32/32 passed
- ctest --test-dir simulate/build --output-on-failure: 2/2 passed