### PR TITLE
ci: add guarded Atlas issue dispatcher

### DIFF
--- a/.github/ISSUE_TEMPLATE/atlas_task.md
+++ b/.github/ISSUE_TEMPLATE/atlas_task.md
@@ -1,0 +1,18 @@
+---
+name: Atlas task
+about: Run one allow-listed task on the Atlas WSL runner
+title: "[atlas] "
+labels: atlas-task
+assignees: ""
+---
+
+Only repository owners, members, and collaborators can start Atlas work.
+
+Put exactly one JSON object in the body:
+
+~~~json
+{"task":"repo-smoke","parameters":{}}
+~~~
+
+Allowed tasks currently are repo-smoke and workspace-status. Arbitrary
+commands, paths, branches, and pull-request code are not accepted.

--- a/.github/workflows/atlas-task.yml
+++ b/.github/workflows/atlas-task.yml
@@ -1,0 +1,80 @@
+name: Atlas task dispatcher
+
+on:
+  issues:
+    types: [opened]
+
+# This workflow intentionally has no pull_request trigger. It checks out only
+# the trusted default branch before running the fixed dispatcher.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: atlas-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'atlas-task') &&
+      (
+        github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'
+      )
+    runs-on: [self-hosted, linux, x64, atlas]
+    timeout-minutes: 30
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Mark Atlas task running
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 tools/atlas_issue_state.py --event "$GITHUB_EVENT_PATH" --state running
+
+      - name: Run fixed Atlas dispatcher
+        run: |
+          mkdir -p "$RUNNER_TEMP/atlas-result"
+          python3 tools/atlas_dispatch.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --output-dir "$RUNNER_TEMP/atlas-result"
+
+      - name: Upload Atlas result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: atlas-issue-${{ github.event.issue.number }}
+          path: ${{ runner.temp }}/atlas-result
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Mark Atlas task complete
+        if: success()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/atlas_issue_state.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --state complete \
+            --summary-file "$RUNNER_TEMP/atlas-result/summary.md"
+
+      - name: Mark Atlas task failed
+        if: failure()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/atlas_issue_state.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --state failed \
+            --summary-file "$RUNNER_TEMP/atlas-result/summary.md"

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -9,7 +9,7 @@ jobs:
   portable-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Check shell syntax

--- a/docs/ATLAS_RUNNER.md
+++ b/docs/ATLAS_RUNNER.md
@@ -1,0 +1,27 @@
+# Atlas task runner
+
+This repository can dispatch a small allow-list of maintenance tasks to the
+Atlas WSL2 Ubuntu-22.04 self-hosted runner through a labeled GitHub Issue.
+
+The Atlas task dispatcher workflow listens only for newly opened issues with
+the atlas-task label, and only accepts issues authored by an owner, member, or
+collaborator. It has no pull-request trigger. Before execution it checks out
+the trusted main branch with credentials removed. The issue body is parsed as
+data; it is never passed to a shell.
+
+The current task contract is:
+
+~~~json
+{"task":"repo-smoke","parameters":{}}
+~~~
+
+The only tasks are repo-smoke and workspace-status. Each task is mapped to
+fixed argument lists in tools/atlas_dispatch.py; arbitrary commands,
+arguments, paths, branches, and PR contents are rejected. Results are written
+to an artifact and summarized back on the Issue. Successful Issues are labeled
+atlas-complete and closed; failures are labeled atlas-failed and remain open.
+
+The runner is installed outside the checkout at
+/home/che/actions-runner, registered as atlas, and managed by its systemd
+service. Windows starts the WSL instance with the Codex Atlas WSL runner
+keepalive scheduled task so the service can reconnect after reboot.

--- a/tools/atlas_dispatch.py
+++ b/tools/atlas_dispatch.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Run the small, explicit allow-list of tasks accepted by Atlas."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+MAX_BODY_BYTES = 16_384
+MAX_TEXT_CHARS = 4_000
+SCHEMA_VERSION = 1
+ALLOWED_TASKS = ("repo-smoke", "workspace-status")
+
+
+class TaskError(ValueError):
+    """A request does not match the dispatcher contract."""
+
+
+def _load_event(event_path: Path) -> dict[str, Any]:
+    try:
+        event = json.loads(event_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TaskError(f"cannot read GitHub event: {exc}") from exc
+    if not isinstance(event, dict):
+        raise TaskError("GitHub event must be a JSON object")
+    return event
+
+
+def _extract_command(event: dict[str, Any]) -> tuple[dict[str, Any], int | None]:
+    issue = event.get("issue")
+    if not isinstance(issue, dict):
+        raise TaskError("event does not contain an issue")
+    issue_number = issue.get("number")
+    if not isinstance(issue_number, int) or issue_number <= 0:
+        raise TaskError("event issue number is invalid")
+
+    body = issue.get("body") or ""
+    if not isinstance(body, str):
+        raise TaskError("issue body must be text")
+    if len(body.encode("utf-8")) > MAX_BODY_BYTES:
+        raise TaskError("issue body is too large")
+
+    blocks = re.findall(r"~~~(?:json)?\s*(.*?)\s*~~~", body, flags=re.IGNORECASE | re.DOTALL)
+    if not blocks:
+        blocks = re.findall(r"\x60\x60\x60(?:json)?\s*(.*?)\s*\x60\x60\x60", body, flags=re.IGNORECASE | re.DOTALL)
+    candidate = blocks[0].strip() if len(blocks) == 1 else body.strip()
+    if not candidate:
+        raise TaskError("issue body must contain one JSON task object")
+    try:
+        command = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise TaskError(f"task JSON is invalid: {exc.msg}") from exc
+    if not isinstance(command, dict):
+        raise TaskError("task JSON must be an object")
+    unknown = sorted(set(command) - {"task", "parameters"})
+    if unknown:
+        raise TaskError(f"unsupported task fields: {', '.join(unknown)}")
+
+    task = command.get("task")
+    if not isinstance(task, str) or task not in ALLOWED_TASKS:
+        allowed = ", ".join(ALLOWED_TASKS)
+        raise TaskError(f"task must be one of: {allowed}")
+    parameters = command.get("parameters", {})
+    if not isinstance(parameters, dict) or parameters:
+        raise TaskError("parameters must be an empty object for the current task set")
+    return {"task": task, "parameters": parameters}, issue_number
+
+
+def _run(argv: list[str], repo_root: Path, timeout: int = 120) -> str:
+    completed = subprocess.run(
+        argv,
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    output = (completed.stdout + completed.stderr).strip()
+    if completed.returncode:
+        detail = output[-MAX_TEXT_CHARS:] if output else "no command output"
+        raise TaskError(f"{argv[0]} failed with exit code {completed.returncode}: {detail}")
+    return output[-MAX_TEXT_CHARS:]
+
+
+def _repo_smoke(repo_root: Path) -> dict[str, Any]:
+    checked = []
+    for relative in ("tools/atlas_dispatch.py", "tools/atlas_issue_state.py"):
+        path = repo_root / relative
+        if not path.is_file():
+            raise TaskError(f"required file is missing: {relative}")
+        ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        checked.append(relative)
+    _run(["git", "diff", "--check"], repo_root)
+    return {"checks": checked + ["git diff --check"]}
+
+
+def _workspace_status(repo_root: Path) -> dict[str, Any]:
+    sha = _run(["git", "rev-parse", "HEAD"], repo_root)
+    status = _run(["git", "status", "--short", "--branch"], repo_root)
+    return {"source_sha": sha, "git_status": status}
+
+
+def _run_task(task: str, repo_root: Path) -> dict[str, Any]:
+    if task == "repo-smoke":
+        return _repo_smoke(repo_root)
+    if task == "workspace-status":
+        return _workspace_status(repo_root)
+    raise TaskError(f"unhandled task: {task}")
+
+
+def _write_outputs(
+    output_dir: Path,
+    *,
+    issue_number: int | None,
+    task: str | None,
+    status: str,
+    source_sha: str | None,
+    details: dict[str, Any],
+    error: str | None,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "issue_number": issue_number,
+        "task": task,
+        "source_sha": source_sha,
+        "details": details,
+        "error": error,
+    }
+    (output_dir / "result.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    lines = [
+        "# Atlas task result",
+        "",
+        f"- Status: {status}",
+        f"- Issue: #{issue_number}" if issue_number is not None else "- Issue: unknown",
+        f"- Task: {task}" if task else "- Task: unknown",
+        f"- Source SHA: {source_sha}" if source_sha else "- Source SHA: unknown",
+    ]
+    if details:
+        lines.extend(["", "## Details", "", "~~~json", json.dumps(details, indent=2, sort_keys=True), "~~~"])
+    if error:
+        lines.extend(["", "## Error", "", error[:MAX_TEXT_CHARS]])
+    (output_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    issue_number: int | None = None
+    task: str | None = None
+    source_sha: str | None = None
+    status = "failure"
+    details: dict[str, Any] = {}
+    error: str | None = None
+    repo_root = Path(__file__).resolve().parents[1]
+
+    try:
+        event = _load_event(args.event)
+        command, issue_number = _extract_command(event)
+        task = command["task"]
+        source_sha = _run(["git", "rev-parse", "HEAD"], repo_root)
+        details = _run_task(task, repo_root)
+        status = "success"
+    except (OSError, subprocess.SubprocessError, TaskError) as exc:
+        error = str(exc)
+    except Exception as exc:  # Keep a result artifact even for unexpected failures.
+        error = f"unexpected dispatcher error: {type(exc).__name__}: {exc}"
+
+    _write_outputs(
+        args.output_dir,
+        issue_number=issue_number,
+        task=task,
+        status=status,
+        source_sha=source_sha,
+        details=details,
+        error=error,
+    )
+    print((args.output_dir / "summary.md").read_text(encoding="utf-8"), end="")
+    return 0 if status == "success" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/atlas_issue_state.py
+++ b/tools/atlas_issue_state.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Update the issue state for a trusted Atlas workflow run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+API_ROOT = "https://api.github.com"
+API_VERSION = "2022-11-28"
+MAX_COMMENT_CHARS = 6_000
+STATES = ("running", "complete", "failed")
+
+
+class GitHubError(RuntimeError):
+    """A GitHub API operation failed."""
+
+
+def _api(
+    method: str,
+    path: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = Request(
+        API_ROOT + path,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": API_VERSION,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            raw = response.read().decode("utf-8")
+    except (HTTPError, URLError, TimeoutError) as exc:
+        detail = ""
+        if isinstance(exc, HTTPError):
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise GitHubError(f"GitHub API {method} {path} failed: {detail or exc}") from exc
+    return json.loads(raw) if raw else None
+
+
+def _event(path: Path) -> tuple[str, int]:
+    try:
+        event = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GitHubError(f"cannot read GitHub event: {exc}") from exc
+    repository = event.get("repository", {})
+    issue = event.get("issue", {})
+    full_name = repository.get("full_name")
+    number = issue.get("number")
+    if not isinstance(full_name, str) or not full_name:
+        raise GitHubError("event repository is missing")
+    if not isinstance(number, int) or number <= 0:
+        raise GitHubError("event issue number is invalid")
+    return full_name, number
+
+
+def _issue_path(full_name: str, number: int, suffix: str = "") -> str:
+    return f"/repos/{full_name}/issues/{number}{suffix}"
+
+
+def _label_path(full_name: str, number: int, label: str) -> str:
+    return _issue_path(full_name, number, f"/labels/{quote(label, safe='')}")
+
+
+def _set_state(
+    *,
+    full_name: str,
+    number: int,
+    token: str,
+    state: str,
+    summary_file: Path | None,
+) -> None:
+    _api("POST", _issue_path(full_name, number, "/labels"), token, {"labels": [f"atlas-{state}"]})
+    for old_state in ("running", "complete", "failed"):
+        if old_state != state:
+            try:
+                _api("DELETE", _label_path(full_name, number, f"atlas-{old_state}"), token)
+            except GitHubError as exc:
+                if "404" not in str(exc):
+                    raise
+
+    run_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    workflow_url = f"{run_url}/{full_name}/actions/runs/{run_id}" if run_id else run_url
+    if summary_file and summary_file.is_file():
+        summary = summary_file.read_text(encoding="utf-8")[:MAX_COMMENT_CHARS]
+    else:
+        summary = "No result summary was produced."
+
+    if state == "running":
+        body = "Atlas accepted this allow-listed task and started it.\n\n" + workflow_url
+    elif state == "complete":
+        body = "Atlas completed the allow-listed task.\n\n" + summary + "\nWorkflow: " + workflow_url
+    else:
+        body = "Atlas could not complete the allow-listed task.\n\n" + summary + "\nWorkflow: " + workflow_url
+    _api("POST", _issue_path(full_name, number, "/comments"), token, {"body": body[:MAX_COMMENT_CHARS]})
+
+    if state == "complete":
+        _api(
+            "PATCH",
+            _issue_path(full_name, number),
+            token,
+            {"state": "closed", "state_reason": "completed"},
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--state", choices=STATES, required=True)
+    parser.add_argument("--summary-file", type=Path)
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("GITHUB_TOKEN is required")
+    full_name, number = _event(args.event)
+    _set_state(
+        full_name=full_name,
+        number=number,
+        token=token,
+        state=args.state,
+        summary_file=args.summary_file,
+    )
+    print(f"Atlas issue #{number}: {args.state}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- register Atlas as the repository self-hosted runner target
- dispatch only allow-listed tasks from trusted Issue authors
- checkout only main, never execute pull-request contents, and return artifacts/status
- pin the hosted checkout action

## Validation
- dispatcher success, fenced JSON, and rejection tests pass
- Python syntax, YAML parse, and git diff checks pass
